### PR TITLE
Add `Webhook`s for `GardenerShootControlPlane`

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -17,4 +17,7 @@ resources:
   kind: GardenerShootControlPlane
   path: github.com/gardener/cluster-api-provider-gardener/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 version: "3"

--- a/PROJECT
+++ b/PROJECT
@@ -18,6 +18,7 @@ resources:
   path: github.com/gardener/cluster-api-provider-gardener/api/v1alpha1
   version: v1alpha1
   webhooks:
+    defaulting: true
     validation: true
     webhookVersion: v1
 version: "3"

--- a/api/v1alpha1/gardenershootcluster_types.go
+++ b/api/v1alpha1/gardenershootcluster_types.go
@@ -60,9 +60,11 @@ type GardenerShootControlPlaneSpec struct {
 	// +optional
 	Version string `json:"version,omitempty"`
 
-	// Project is the project in which the Shoot should be placed in.
+	// ProjectNamespace is the namespace in which the Shoot should be placed in.
+	// This has to be a valid project namespace within the Gardener cluster.
+	// If not set, the namespace of this object will be used in the Gardener cluster.
 	// +optional
-	Project string `json:"project,omitempty"`
+	ProjectNamespace string `json:"projectNamespace,omitempty"`
 
 	// ShootSpec is the specification of the desired Shoot cluster.
 	// + optional

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -261,7 +261,8 @@ func main() {
 	}
 	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err = webhookcontrolplanev1alpha1.SetupGardenerShootControlPlaneWebhookWithManager(mgr, gardenMgr.GetClient()); err != nil {
+		if err = webhookcontrolplanev1alpha1.
+			SetupGardenerShootControlPlaneWebhookWithManager(mgr, gardenMgr.GetClient()); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "GardenerShootControlPlane")
 			os.Exit(1)
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,6 +45,7 @@ import (
 
 	controlplanev1alpha1 "github.com/gardener/cluster-api-provider-gardener/api/v1alpha1"
 	"github.com/gardener/cluster-api-provider-gardener/internal/controller"
+	webhookcontrolplanev1alpha1 "github.com/gardener/cluster-api-provider-gardener/internal/webhook/v1alpha1"
 )
 
 var (
@@ -257,6 +258,15 @@ func main() {
 	}).SetupWithManager(mgr, gardenMgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GardenerShootControlPlane")
 		os.Exit(1)
+	}
+	// nolint:goconst
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err = webhookcontrolplanev1alpha1.SetupGardenerShootControlPlaneWebhookWithManager(mgr, gardenMgr.GetClient()); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "GardenerShootControlPlane")
+			os.Exit(1)
+		}
+	} else {
+		setupLog.Info("Skipping webhook setup")
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -318,7 +318,7 @@ func (f *fieldIndexer) Start(ctx context.Context) error {
 				return nil
 			}
 			return []string{client.ObjectKey{
-				Namespace: "garden-" + controlPlane.Spec.Project,
+				Namespace: controlPlane.Spec.ProjectNamespace,
 				Name:      controlPlane.GetName()}.String(),
 			}
 		})

--- a/config/certmanager/certificate-metrics.yaml
+++ b/config/certmanager/certificate-metrics.yaml
@@ -1,0 +1,20 @@
+# The following manifests contain a self-signed issuer CR and a metrics certificate CR.
+# More document can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: cluster-api-provider-gardener
+    app.kubernetes.io/managed-by: kustomize
+  name: metrics-certs  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  dnsNames:
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+  # replacements in the config/default/kustomization.yaml file.
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert

--- a/config/certmanager/certificate-webhook.yaml
+++ b/config/certmanager/certificate-webhook.yaml
@@ -1,0 +1,20 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: cluster-api-provider-gardener
+    app.kubernetes.io/managed-by: kustomize
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+  # replacements in the config/default/kustomization.yaml file.
+  dnsNames:
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert

--- a/config/certmanager/issuer.yaml
+++ b/config/certmanager/issuer.yaml
@@ -1,0 +1,13 @@
+# The following manifest contains a self-signed issuer CR.
+# More information can be found at https://docs.cert-manager.io
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/name: cluster-api-provider-gardener
+    app.kubernetes.io/managed-by: kustomize
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- issuer.yaml
+- certificate-webhook.yaml
+- certificate-metrics.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+# This configuration is for teaching kustomize how to update name ref substitution
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_gardenershootcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_gardenershootcontrolplanes.yaml
@@ -68,9 +68,11 @@ spec:
                 - host
                 - port
                 type: object
-              project:
-                description: Project is the project in which the Shoot should be placed
-                  in.
+              projectNamespace:
+                description: |-
+                  ProjectNamespace is the namespace in which the Shoot should be placed in.
+                  This has to be a valid project namespace within the Gardener cluster.
+                  If not set, the namespace of this object will be used in the Gardener cluster.
                 type: string
               shootSpec:
                 description: ShootSpec is the specification of the desired Shoot cluster.

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -16,5 +16,5 @@ patches:
 
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.
-#configurations:
-#- kustomizeconfig.yaml
+configurations:
+- kustomizeconfig.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -23,9 +23,9 @@ resources:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
@@ -53,13 +53,13 @@ patches:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- path: manager_webhook_patch.yaml
-#  target:
-#    kind: Deployment
+- path: manager_webhook_patch.yaml
+  target:
+    kind: Deployment
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations
-#replacements:
+replacements:
 # - source: # Uncomment the following block to enable certificates for metrics
 #     kind: Service
 #     version: v1
@@ -120,73 +120,73 @@ patches:
 #         index: 1
 #         create: true
 #
-# - source: # Uncomment the following block if you have any webhook
-#     kind: Service
-#     version: v1
-#     name: webhook-service
-#     fieldPath: .metadata.name # Name of the service
-#   targets:
-#     - select:
-#         kind: Certificate
-#         group: cert-manager.io
-#         version: v1
-#         name: serving-cert
-#       fieldPaths:
-#         - .spec.dnsNames.0
-#         - .spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 0
-#         create: true
-# - source:
-#     kind: Service
-#     version: v1
-#     name: webhook-service
-#     fieldPath: .metadata.namespace # Namespace of the service
-#   targets:
-#     - select:
-#         kind: Certificate
-#         group: cert-manager.io
-#         version: v1
-#         name: serving-cert
-#       fieldPaths:
-#         - .spec.dnsNames.0
-#         - .spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 1
-#         create: true
+ - source: # Uncomment the following block if you have any webhook
+     kind: Service
+     version: v1
+     name: webhook-service
+     fieldPath: .metadata.name # Name of the service
+   targets:
+     - select:
+         kind: Certificate
+         group: cert-manager.io
+         version: v1
+         name: serving-cert
+       fieldPaths:
+         - .spec.dnsNames.0
+         - .spec.dnsNames.1
+       options:
+         delimiter: '.'
+         index: 0
+         create: true
+ - source:
+     kind: Service
+     version: v1
+     name: webhook-service
+     fieldPath: .metadata.namespace # Namespace of the service
+   targets:
+     - select:
+         kind: Certificate
+         group: cert-manager.io
+         version: v1
+         name: serving-cert
+       fieldPaths:
+         - .spec.dnsNames.0
+         - .spec.dnsNames.1
+       options:
+         delimiter: '.'
+         index: 1
+         create: true
 #
-# - source: # Uncomment the following block if you have a ValidatingWebhook (--programmatic-validation)
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert # This name should match the one in certificate.yaml
-#     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets:
-#     - select:
-#         kind: ValidatingWebhookConfiguration
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 0
-#         create: true
-# - source:
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert
-#     fieldPath: .metadata.name
-#   targets:
-#     - select:
-#         kind: ValidatingWebhookConfiguration
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 1
-#         create: true
+ - source: # Uncomment the following block if you have a ValidatingWebhook (--programmatic-validation)
+     kind: Certificate
+     group: cert-manager.io
+     version: v1
+     name: serving-cert # This name should match the one in certificate.yaml
+     fieldPath: .metadata.namespace # Namespace of the certificate CR
+   targets:
+     - select:
+         kind: ValidatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 0
+         create: true
+ - source:
+     kind: Certificate
+     group: cert-manager.io
+     version: v1
+     name: serving-cert
+     fieldPath: .metadata.name
+   targets:
+     - select:
+         kind: ValidatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 1
+         create: true
 #
 # - source: # Uncomment the following block if you have a DefaultingWebhook (--defaulting )
 #     kind: Certificate

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -187,37 +187,37 @@ replacements:
          delimiter: '/'
          index: 1
          create: true
-#
-# - source: # Uncomment the following block if you have a DefaultingWebhook (--defaulting )
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert
-#     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets:
-#     - select:
-#         kind: MutatingWebhookConfiguration
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 0
-#         create: true
-# - source:
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert
-#     fieldPath: .metadata.name
-#   targets:
-#     - select:
-#         kind: MutatingWebhookConfiguration
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 1
-#         create: true
+
+ - source: # Uncomment the following block if you have a DefaultingWebhook (--defaulting )
+     kind: Certificate
+     group: cert-manager.io
+     version: v1
+     name: serving-cert
+     fieldPath: .metadata.namespace # Namespace of the certificate CR
+   targets:
+     - select:
+         kind: MutatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 0
+         create: true
+ - source:
+     kind: Certificate
+     group: cert-manager.io
+     version: v1
+     name: serving-cert
+     fieldPath: .metadata.name
+   targets:
+     - select:
+         kind: MutatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 1
+         create: true
 #
 # - source: # Uncomment the following block if you have a ConversionWebhook (--conversion)
 #     kind: Certificate

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,31 @@
+# This patch ensures the webhook certificates are properly mounted in the manager container.
+# It configures the necessary arguments, volumes, volume mounts, and container ports.
+
+# Add the --webhook-cert-path argument for configuring the webhook certificate path
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+
+# Add the volumeMount for the webhook certificates
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    mountPath: /tmp/k8s-webhook-server/serving-certs
+    name: webhook-certs
+    readOnly: true
+
+# Add the port configuration for the webhook server
+- op: add
+  path: /spec/template/spec/containers/0/ports/-
+  value:
+    containerPort: 9443
+    name: webhook-server
+    protocol: TCP
+
+# Add the volume configuration for the webhook certificates
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: webhook-certs
+    secret:
+      secretName: webhook-server-cert

--- a/config/network-policy/allow-webhook-traffic.yaml
+++ b/config/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,27 @@
+# This NetworkPolicy allows ingress traffic to your webhook server running
+# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
+# will only work when applied in namespaces labeled with 'webhook: enabled'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: cluster-api-provider-gardener
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-webhook-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: cluster-api-provider-gardener
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label webhook: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled # Only from namespaces with this label
+      ports:
+        - port: 443
+          protocol: TCP

--- a/config/network-policy/kustomization.yaml
+++ b/config/network-policy/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
+- allow-webhook-traffic.yaml
 - allow-metrics-traffic.yaml

--- a/config/samples/controlplane_v1alpha1_gardenershootcontrolplane.yaml
+++ b/config/samples/controlplane_v1alpha1_gardenershootcontrolplane.yaml
@@ -16,7 +16,8 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: hello-gardener
 spec:
-  project: local
+  # Defaulted to this objects namespace if not provided.
+  projectNamespace: garden-local
   shootSpec:
       cloudProfile:
         kind: CloudProfile

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,22 @@
+# the following config is for teaching kustomize where to look at when substituting nameReference.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,5 +1,31 @@
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-controlplane-cluster-x-k8s-io-v1alpha1-gardenershootcontrolplane
+  failurePolicy: Fail
+  name: vgardenershootcontrolplane-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gardenershootcontrolplanes
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-controlplane-cluster-x-k8s-io-v1alpha1-gardenershootcontrolplane
+  failurePolicy: Fail
+  name: vgardenershootcontrolplane-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gardenershootcontrolplanes
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: cluster-api-provider-gardener
+    app.kubernetes.io/managed-by: kustomize
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager
+    app.kubernetes.io/name: cluster-api-provider-gardener

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,10 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/onsi/ginkgo/v2 v2.23.0
 	github.com/onsi/gomega v1.36.2
+	k8s.io/api v0.32.3
 	k8s.io/apimachinery v0.32.3
 	k8s.io/client-go v0.32.3
+	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	sigs.k8s.io/cluster-api v1.9.5
 	sigs.k8s.io/controller-runtime v0.20.3
 )
@@ -119,7 +121,6 @@ require (
 	helm.sh/helm/v3 v3.17.1 // indirect
 	istio.io/api v1.24.3 // indirect
 	istio.io/client-go v1.24.2 // indirect
-	k8s.io/api v0.32.3 // indirect
 	k8s.io/apiextensions-apiserver v0.32.2 // indirect
 	k8s.io/apiserver v0.32.2 // indirect
 	k8s.io/autoscaler/vertical-pod-autoscaler v1.2.2 // indirect
@@ -129,7 +130,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20241212222426-2c72e554b1e7 // indirect
 	k8s.io/kubelet v0.32.2 // indirect
 	k8s.io/metrics v0.32.2 // indirect
-	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.5.0 // indirect

--- a/internal/controller/gardenershootcontrolplane_controller.go
+++ b/internal/controller/gardenershootcontrolplane_controller.go
@@ -349,14 +349,10 @@ func controlPlaneReady(shootStatus gardenercorev1beta1.ShootStatus) bool {
 }
 
 func ShootFromControlPlane(shootControlPlane *controlplanev1alpha1.GardenerShootControlPlane) *gardenercorev1beta1.Shoot {
-	shootNamespace := shootControlPlane.Namespace
-	if len(shootControlPlane.Spec.Project) > 0 {
-		shootNamespace = "garden-" + shootControlPlane.Spec.Project
-	}
 	return &gardenercorev1beta1.Shoot{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      shootControlPlane.Name,
-			Namespace: shootNamespace,
+			Namespace: shootControlPlane.Spec.ProjectNamespace,
 		},
 		Spec: shootControlPlane.Spec.ShootSpec,
 	}

--- a/internal/controller/gardenershootcontrolplane_controller.go
+++ b/internal/controller/gardenershootcontrolplane_controller.go
@@ -106,17 +106,7 @@ func (r *GardenerShootControlPlaneReconciler) Reconcile(ctx context.Context, req
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	shootNamespace := cpc.shootControlPlane.Namespace
-	if len(cpc.shootControlPlane.Spec.Project) > 0 {
-		shootNamespace = "garden-" + cpc.shootControlPlane.Spec.Project
-	}
-	cpc.shoot = &gardenercorev1beta1.Shoot{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cpc.shootControlPlane.Name,
-			Namespace: shootNamespace,
-		},
-		Spec: cpc.shootControlPlane.Spec.ShootSpec,
-	}
+	cpc.shoot = ShootFromControlPlane(cpc.shootControlPlane)
 
 	// Handle deleted clusters
 	if !cpc.shootControlPlane.DeletionTimestamp.IsZero() {
@@ -356,6 +346,21 @@ func controlPlaneReady(shootStatus gardenercorev1beta1.ShootStatus) bool {
 		}
 	}
 	return false
+}
+
+func ShootFromControlPlane(shootControlPlane *controlplanev1alpha1.GardenerShootControlPlane) *gardenercorev1beta1.Shoot {
+	shootNamespace := shootControlPlane.Namespace
+	if len(shootControlPlane.Spec.Project) > 0 {
+		shootNamespace = "garden-" + shootControlPlane.Spec.Project
+	}
+	return &gardenercorev1beta1.Shoot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      shootControlPlane.Name,
+			Namespace: shootNamespace,
+		},
+		Spec: shootControlPlane.Spec.ShootSpec,
+	}
+
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/webhook/v1alpha1/gardenershootcontrolplane_webhook.go
+++ b/internal/webhook/v1alpha1/gardenershootcontrolplane_webhook.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+	"github.com/gardener/cluster-api-provider-gardener/internal/controller"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	controlplanev1alpha1 "github.com/gardener/cluster-api-provider-gardener/api/v1alpha1"
+)
+
+// nolint:unused
+// log is for logging in this package.
+var _ = logf.Log.WithName("gardenershootcontrolplane-resource")
+
+// SetupGardenerShootControlPlaneWebhookWithManager registers the webhook for GardenerShootControlPlane in the manager.
+func SetupGardenerShootControlPlaneWebhookWithManager(mgr ctrl.Manager, gardenerClient client.Client) error {
+	return ctrl.NewWebhookManagedBy(mgr).For(&controlplanev1alpha1.GardenerShootControlPlane{}).
+		WithValidator(&GardenerShootControlPlaneCustomValidator{
+			GardenerClient: gardenerClient,
+		}).
+		Complete()
+}
+
+// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
+// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
+// +kubebuilder:webhook:path=/validate-controlplane-cluster-x-k8s-io-v1alpha1-gardenershootcontrolplane,mutating=false,failurePolicy=fail,sideEffects=None,groups=controlplane.cluster.x-k8s.io,resources=gardenershootcontrolplanes,verbs=create;update,versions=v1alpha1,name=vgardenershootcontrolplane-v1alpha1.kb.io,admissionReviewVersions=v1
+
+// GardenerShootControlPlaneCustomValidator struct is responsible for validating the GardenerShootControlPlane resource
+// when it is created, updated, or deleted.
+//
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as this struct is used only for temporary operations and does not need to be deeply copied.
+type GardenerShootControlPlaneCustomValidator struct {
+	GardenerClient client.Client
+}
+
+var _ webhook.CustomValidator = &GardenerShootControlPlaneCustomValidator{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type GardenerShootControlPlane.
+func (v *GardenerShootControlPlaneCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	shootControlPlane, ok := obj.(*controlplanev1alpha1.GardenerShootControlPlane)
+	if !ok {
+		return nil, fmt.Errorf("expected a GardenerShootControlPlane object but got %T", obj)
+	}
+
+	return nil, v.GardenerClient.Create(ctx, controller.ShootFromControlPlane(shootControlPlane), &client.CreateOptions{DryRun: []string{"All"}})
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type GardenerShootControlPlane.
+func (v *GardenerShootControlPlaneCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	shootControlPlane, ok := newObj.(*controlplanev1alpha1.GardenerShootControlPlane)
+	if !ok {
+		return nil, fmt.Errorf("expected a GardenerShootControlPlane object for the newObj but got %T", newObj)
+	}
+
+	// For the update, we need to get the actual cluster and inject the new config, because e.g. the resourceVersion must be set.
+	shoot := controller.ShootFromControlPlane(shootControlPlane)
+	if err := v.GardenerClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot); err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+
+	shoot.Spec = shootControlPlane.Spec.ShootSpec
+
+	// During deletion, it can happen that the Shoot wants to be patched, when it does not exist anymore,
+	// therefore ignoring this error to prevent the reconciliation to be blocked.
+	return nil, client.IgnoreNotFound(v.GardenerClient.Update(ctx, shoot, &client.UpdateOptions{DryRun: []string{"All"}}))
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type GardenerShootControlPlane.
+func (v *GardenerShootControlPlaneCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	_, ok := obj.(*controlplanev1alpha1.GardenerShootControlPlane)
+	if !ok {
+		return nil, fmt.Errorf("expected a GardenerShootControlPlane object but got %T", obj)
+	}
+
+	return nil, nil
+}

--- a/internal/webhook/v1alpha1/gardenershootcontrolplane_webhook.go
+++ b/internal/webhook/v1alpha1/gardenershootcontrolplane_webhook.go
@@ -19,16 +19,16 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
-	"github.com/gardener/cluster-api-provider-gardener/internal/controller"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	controlplanev1alpha1 "github.com/gardener/cluster-api-provider-gardener/api/v1alpha1"
+	"github.com/gardener/cluster-api-provider-gardener/internal/controller"
 )
 
 // nolint:unused

--- a/internal/webhook/v1alpha1/gardenershootcontrolplane_webhook_test.go
+++ b/internal/webhook/v1alpha1/gardenershootcontrolplane_webhook_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	controlplanev1alpha1 "github.com/gardener/cluster-api-provider-gardener/api/v1alpha1"
+)
+
+var _ = Describe("GardenerShootControlPlane Webhook", func() {
+	var (
+		obj       *controlplanev1alpha1.GardenerShootControlPlane
+		oldObj    *controlplanev1alpha1.GardenerShootControlPlane
+		validator GardenerShootControlPlaneCustomValidator
+	)
+
+	BeforeEach(func() {
+		obj = &controlplanev1alpha1.GardenerShootControlPlane{}
+		oldObj = &controlplanev1alpha1.GardenerShootControlPlane{}
+		validator = GardenerShootControlPlaneCustomValidator{}
+		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
+		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
+		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
+		// TODO (user): Add any setup logic common to all tests
+	})
+
+	AfterEach(func() {
+		// TODO (user): Add any teardown logic common to all tests
+	})
+
+	Context("When creating or updating GardenerShootControlPlane under Validating Webhook", func() {
+		// TODO (user): Add logic for validating webhooks
+		// Example:
+		// It("Should deny creation if a required field is missing", func() {
+		//     By("simulating an invalid creation scenario")
+		//     obj.SomeRequiredField = ""
+		//     Expect(validator.ValidateCreate(ctx, obj)).Error().To(HaveOccurred())
+		// })
+		//
+		// It("Should admit creation if all required fields are present", func() {
+		//     By("simulating an invalid creation scenario")
+		//     obj.SomeRequiredField = "valid_value"
+		//     Expect(validator.ValidateCreate(ctx, obj)).To(BeNil())
+		// })
+		//
+		// It("Should validate updates correctly", func() {
+		//     By("simulating a valid update scenario")
+		//     oldObj.SomeRequiredField = "updated_value"
+		//     obj.SomeRequiredField = "updated_value"
+		//     Expect(validator.ValidateUpdate(ctx, oldObj, obj)).To(BeNil())
+		// })
+	})
+
+})

--- a/internal/webhook/v1alpha1/gardenershootcontrolplane_webhook_test.go
+++ b/internal/webhook/v1alpha1/gardenershootcontrolplane_webhook_test.go
@@ -27,14 +27,14 @@ var _ = Describe("GardenerShootControlPlane Webhook", func() {
 	var (
 		obj       *controlplanev1alpha1.GardenerShootControlPlane
 		oldObj    *controlplanev1alpha1.GardenerShootControlPlane
-		validator GardenerShootControlPlaneCustomValidator
+		defaulter GardenerShootControlPlaneCustomDefaulter
 	)
 
 	BeforeEach(func() {
 		obj = &controlplanev1alpha1.GardenerShootControlPlane{}
 		oldObj = &controlplanev1alpha1.GardenerShootControlPlane{}
-		validator = GardenerShootControlPlaneCustomValidator{}
-		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
+		defaulter = GardenerShootControlPlaneCustomDefaulter{}
+		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
 		// TODO (user): Add any setup logic common to all tests
@@ -44,26 +44,16 @@ var _ = Describe("GardenerShootControlPlane Webhook", func() {
 		// TODO (user): Add any teardown logic common to all tests
 	})
 
-	Context("When creating or updating GardenerShootControlPlane under Validating Webhook", func() {
-		// TODO (user): Add logic for validating webhooks
+	Context("When creating GardenerShootControlPlane under Defaulting Webhook", func() {
+		// TODO (user): Add logic for defaulting webhooks
 		// Example:
-		// It("Should deny creation if a required field is missing", func() {
-		//     By("simulating an invalid creation scenario")
-		//     obj.SomeRequiredField = ""
-		//     Expect(validator.ValidateCreate(ctx, obj)).Error().To(HaveOccurred())
-		// })
-		//
-		// It("Should admit creation if all required fields are present", func() {
-		//     By("simulating an invalid creation scenario")
-		//     obj.SomeRequiredField = "valid_value"
-		//     Expect(validator.ValidateCreate(ctx, obj)).To(BeNil())
-		// })
-		//
-		// It("Should validate updates correctly", func() {
-		//     By("simulating a valid update scenario")
-		//     oldObj.SomeRequiredField = "updated_value"
-		//     obj.SomeRequiredField = "updated_value"
-		//     Expect(validator.ValidateUpdate(ctx, oldObj, obj)).To(BeNil())
+		// It("Should apply defaults when a required field is empty", func() {
+		//     By("simulating a scenario where defaults should be applied")
+		//     obj.SomeFieldWithDefault = ""
+		//     By("calling the Default method to apply defaults")
+		//     defaulter.Default(ctx, obj)
+		//     By("checking that the default values are set")
+		//     Expect(obj.SomeFieldWithDefault).To(Equal("default_value"))
 		// })
 	})
 

--- a/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	controlplanev1alpha1 "github.com/gardener/cluster-api-provider-gardener/api/v1alpha1"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	var err error
+	err = controlplanev1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		},
+	}
+
+	// Retrieve the first found binary directory to allow running tests from IDEs
+	if getFirstFoundEnvTestBinaryDir() != "" {
+		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
+	}
+
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// start webhook server using Manager.
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	// TODO(tobschli): Change this Client to get the actual Gardener client.
+	err = SetupGardenerShootControlPlaneWebhookWithManager(mgr, mgr.GetClient())
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:webhook
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// wait for the webhook server to get ready.
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+
+		return conn.Close()
+	}).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
+// ENVTEST-based tests depend on specific binaries, usually located in paths set by
+// controller-runtime. When running tests directly (e.g., via an IDE) without using
+// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
+//
+// This function streamlines the process by finding the required binaries, similar to
+// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
+// properly set up, run 'make setup-envtest' beforehand.
+func getFirstFoundEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -280,6 +280,20 @@ var _ = Describe("Manager", Ordered, func() {
 			Eventually(verifyCAInjection).Should(Succeed())
 		})
 
+		It("should have CA injection for mutating webhooks", func() {
+			By("checking CA injection for mutating webhooks")
+			verifyCAInjection := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get",
+					"mutatingwebhookconfigurations.admissionregistration.k8s.io",
+					"cluster-api-provider-gardener-mutating-webhook-configuration",
+					"-o", "go-template={{ range .webhooks }}{{ .clientConfig.caBundle }}{{ end }}")
+				mwhOutput, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(len(mwhOutput)).To(BeNumerically(">", 10))
+			}
+			Eventually(verifyCAInjection).Should(Succeed())
+		})
+
 		// +kubebuilder:scaffold:e2e-webhooks-checks
 
 		// TODO: Customize the e2e test suite with scenarios specific to your project.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -256,6 +256,30 @@ var _ = Describe("Manager", Ordered, func() {
 			))
 		})
 
+		It("should provisioned cert-manager", func() {
+			By("validating that cert-manager has the certificate Secret")
+			verifyCertManager := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "secrets", "webhook-server-cert", "-n", namespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			Eventually(verifyCertManager).Should(Succeed())
+		})
+
+		It("should have CA injection for validating webhooks", func() {
+			By("checking CA injection for validating webhooks")
+			verifyCAInjection := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get",
+					"validatingwebhookconfigurations.admissionregistration.k8s.io",
+					"cluster-api-provider-gardener-validating-webhook-configuration",
+					"-o", "go-template={{ range .webhooks }}{{ .clientConfig.caBundle }}{{ end }}")
+				vwhOutput, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(len(vwhOutput)).To(BeNumerically(">", 10))
+			}
+			Eventually(verifyCAInjection).Should(Succeed())
+		})
+
 		// +kubebuilder:scaffold:e2e-webhooks-checks
 
 		// TODO: Customize the e2e test suite with scenarios specific to your project.


### PR DESCRIPTION
It builds the Create / Update request for the resulting `Shoot` and does a dry-run against the Gardener-Cluster.

Refactor API from .spec.project to .spec.projectNamespace.

Add `DefaultingWebhook` for `GardenerShootControlPlane`.

The webhook defaults `.spec.projectNamespace` to the `GSCP`s namespace, if not specified.
This is needed, because the indexing relies on the `Shoot`s namespace.