### PR TITLE
Fix sync to enable bi-directional updates between GSCP and Shoot

### DIFF
--- a/internal/controller/gardenershootcontrolplane_controller_test.go
+++ b/internal/controller/gardenershootcontrolplane_controller_test.go
@@ -65,6 +65,7 @@ var _ = Describe("GardenerShootControlPlane Controller", func() {
 			By("Cleanup the specific resource instance GardenerShootControlPlane")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 		})
+
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &GardenerShootControlPlaneReconciler{


### PR DESCRIPTION
Fix sync to enable updates from Shoot to GSCP to get through as well as updates from GSCP towards the Shoot.