### PR TITLE
KCP-awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,30 @@ The `cluster-api-provider-gardener` integrates Gardener with Cluster API, enabli
 using Gardener as the control plane provider.
 This provider allows users to leverage the powerful features of Gardener for cluster lifecycle management.
 
-The controller is also KCP-aware, meaning that it can also be used in as a KCP-controller.
+The controller is also KCP-aware, meaning that it can also be used in KCP as a KCP-controller.
 
 ## Getting Started
 
-### KCP
-#### Prerequisites
+### Common Prerequisites
+
+The following prerequisites apply to all the following deployment-scenarios.
+Please refer to the individual scenario of your choice for the specific prerequisites.
+
 - go version v1.24.0+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.
 - a (local) Gardener cluster
+
+### KCP
+
+#### Prerequisites
+
 - a KCP server (`KUBECONFIG` usually is located in `.kcp/admin.kubeconfig`, relative from where KCP is started)
 - KCP's `kubectl` plugins
 
 #### To Deploy on the cluster
+
 **Create controller workspace:**
 > **NOTE**: For our quick-start, we use `:root:gardener` as our controller-workspace.
 ```shell
@@ -51,17 +60,13 @@ kubectl apply -f schemas/binding.yaml
 ```shell
 kubectl apply -f config/samples/controlplane_v1alpha1_gardenershootcontrolplane.yaml
 ```
+
 ### Cluster-API
 
-#### Prerequisites
-- go version v1.24.0+
-- docker version 17.03+.
-- kubectl version v1.11.3+.
-- Access to a Kubernetes v1.11.3+ cluster.
-- a (local) Gardener cluster
-
 The local-setup assumes, that you deploy Cluster-API next to the virtual Garden-Cluster, which is _not_ intended for production.
+
 #### To Deploy on the cluster
+
 **Build and push your image to the location specified by `IMG`:**
 
 ```sh
@@ -104,6 +109,7 @@ kubectl apply -k config/samples/
 ```
 
 #### To Uninstall
+
 **Delete the instances (CRs) from the cluster:**
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -6,9 +6,54 @@ The `cluster-api-provider-gardener` integrates Gardener with Cluster API, enabli
 using Gardener as the control plane provider.
 This provider allows users to leverage the powerful features of Gardener for cluster lifecycle management.
 
+The controller is also KCP-aware, meaning that it can also be used in as a KCP-controller.
+
 ## Getting Started
 
-### Prerequisites
+### KCP
+#### Prerequisites
+- go version v1.24.0+
+- docker version 17.03+.
+- kubectl version v1.11.3+.
+- Access to a Kubernetes v1.11.3+ cluster.
+- a (local) Gardener cluster
+- a KCP server (`KUBECONFIG` usually is located in `.kcp/admin.kubeconfig`, relative from where KCP is started)
+- KCP's `kubectl` plugins
+
+#### To Deploy on the cluster
+**Create controller workspace:**
+> **NOTE**: For our quick-start, we use `:root:gardener` as our controller-workspace.
+```shell
+kubectl create-workspace gardener --enter
+```
+
+**Create `APIResourceSchema`s, `APIExport` and `APIBinding` in Controller-workspace:**
+```shell
+kubectl apply -f schemas/gardener
+```
+
+> **NOTE**: `APIBinding.spec.reference.export.path` may needs to be adapted when you don't use `:root:gardener` as your controller-workspace.
+```shell
+kubectl apply -f schemas/binding.yaml
+```
+
+**Create and enter consuming workspace:**
+```shell
+kubectl create-workspace test --enter
+```
+
+**Create `APIBinding` for consuming workspace:**
+```shell
+kubectl apply -f schemas/binding.yaml
+```
+
+**Apply `Cluster` and `GardenerShootControlPlane` in consuming workspace:**
+```shell
+kubectl apply -f config/samples/controlplane_v1alpha1_gardenershootcontrolplane.yaml
+```
+### Cluster-API
+
+#### Prerequisites
 - go version v1.24.0+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
@@ -16,7 +61,7 @@ This provider allows users to leverage the powerful features of Gardener for clu
 - a (local) Gardener cluster
 
 The local-setup assumes, that you deploy Cluster-API next to the virtual Garden-Cluster, which is _not_ intended for production.
-### To Deploy on the cluster
+#### To Deploy on the cluster
 **Build and push your image to the location specified by `IMG`:**
 
 ```sh
@@ -58,7 +103,7 @@ You can apply the samples (examples) from the config/sample:
 kubectl apply -k config/samples/
 ```
 
-### To Uninstall
+#### To Uninstall
 **Delete the instances (CRs) from the cluster:**
 
 ```sh

--- a/api/v1alpha1/gardenershootcluster_types.go
+++ b/api/v1alpha1/gardenershootcluster_types.go
@@ -23,7 +23,9 @@ import (
 )
 
 const (
-	ShootReferenceIndexKey = "shootReference"
+	GSCPReferenceNamespaceKey     = "controlplane.cluster.x-k8s.io/gscp_namespace"
+	GSCPReferenceNameKey          = "controlplane.cluster.x-k8s.io/gscp_name"
+	GSCPReferecenceClusterNameKey = "controlplane.cluster.x-k8s.io/gscp_cluster"
 )
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	gardenercorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -22,5 +23,6 @@ func init() {
 
 	utilruntime.Must(gardenercorev1beta1.AddToScheme(Scheme))
 	utilruntime.Must(kubernetes.AddGardenSchemeToScheme(Scheme))
+	utilruntime.Must(apisv1alpha1.AddToScheme(Scheme))
 	// +kubebuilder:scaffold:scheme
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -266,9 +266,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = mgr.Add(&fieldIndexer{mgr: mgr}); err != nil {
-		setupLog.Error(err, "error while initializing field indexer", "controller", "GardenerShootControlPlane")
-		os.Exit(1)
+	// Create reconcilers
+	if isKcp {
+		setupLog.Info("Setting up Cluster reconciler, because KCP API Group is present")
+		if err = (&controller.ClusterController{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "Cluster")
+			os.Exit(1)
+		}
 	}
 
 	if err = (&controller.GardenerShootControlPlaneReconciler{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -91,6 +91,7 @@ func main() {
 	flag.StringVar(&gardenerKubeConfigPath, "gardener-kubeconfig", "", "Path to the Gardener kube-config")
 	flag.DurationVar(&syncPeriod, "sync-period", time.Minute*10,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
+	ctrl.RegisterFlags(flag.CommandLine)
 	opts := zap.Options{
 		Development: true,
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -262,6 +262,9 @@ func main() {
 		Cache: cache.Options{
 			SyncPeriod: &syncPeriod,
 		},
+		BaseContext: func() context.Context {
+			return mgrContext
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to build Gardener rest config")

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,14 @@ module github.com/gardener/cluster-api-provider-gardener
 
 go 1.24.0
 
+replace sigs.k8s.io/controller-runtime => github.com/kcp-dev/controller-runtime v0.19.0-kcp.1
+
 require (
 	github.com/gardener/gardener v1.114.0
 	github.com/go-logr/logr v1.4.2
+	github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20250223115924-431177b024f3
+	github.com/kcp-dev/kcp/sdk v0.27.1
+	github.com/kcp-dev/logicalcluster/v3 v3.0.5
 	github.com/onsi/ginkgo/v2 v2.23.0
 	github.com/onsi/gomega v1.36.2
 	k8s.io/api v0.32.3
@@ -52,7 +57,6 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.22.0 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
@@ -63,10 +67,13 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.23.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kcp-dev/apimachinery v0.0.0-20221102195355-d65878bc16be // indirect
+	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
@@ -104,7 +111,7 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.35.0 // indirect
 	golang.org/x/exp v0.0.0-20250228200357-dead58393ab7 // indirect
-	golang.org/x/net v0.35.0 // indirect
+	golang.org/x/net v0.36.0 // indirect
 	golang.org/x/oauth2 v0.26.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,6 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
-github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/cel-go v0.22.0 h1:b3FJZxpiv1vTMo2/5RDUqAHPxkT8mmMfJIrq1llbf7g=
 github.com/google/cel-go v0.22.0/go.mod h1:BuznPXXfQDpXKWQ9sPW3TzlAJN5zzFe+i9tIs0yC4s8=
 github.com/google/gnostic-models v0.6.9 h1:MU/8wDLif2qCXZmzncUQ/BOfxWfthHi63KqpoNbWqVw=
@@ -208,6 +206,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -223,6 +223,18 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/kcp-dev/apimachinery v0.0.0-20221102195355-d65878bc16be h1:2uDzJ896+ojtzgr9HJL8+tZEoqhq8blwymGinWFrQ6E=
+github.com/kcp-dev/apimachinery v0.0.0-20221102195355-d65878bc16be/go.mod h1:qnvUHkdxOrNzX17yX+z8r81CZEBuFdveNzWqFlwZ55w=
+github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20250223115924-431177b024f3 h1:YwNX7ZIpQXg9u5vav/fobmf4nnO0WhbELWaL3X74Oe4=
+github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20250223115924-431177b024f3/go.mod h1:n0+EV+LGKl1MXXqGbGcn0AaBv7hdKsdazSYuq8nM8Us=
+github.com/kcp-dev/controller-runtime v0.19.0-kcp.1 h1:mbCyVzWuJpg+pkzIkIKLltiOgOSiQ3bqWmHi2mftzgc=
+github.com/kcp-dev/controller-runtime v0.19.0-kcp.1/go.mod h1:jwK5sBnpu/xJJ+xdpSzzI0aM52E/EvF0uLF9bR61h/Y=
+github.com/kcp-dev/kcp/sdk v0.27.1 h1:jBVdrZoJd5hy2RqaBnmCCzldimwOqDkf8FXtNq5HaWA=
+github.com/kcp-dev/kcp/sdk v0.27.1/go.mod h1:3eRgW42d81Ng60DbG1xbne0FSS2znpcN/GUx4rqJgUo=
+github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1 h1:6EMfOioekQNrpcHEK7k2ANBWogFMlf+3xTB3CC4k+2s=
+github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1/go.mod h1:lfWJL764jKFJxZWOGuFuT3PCCLPo6lV5Cl8P7u9T05g=
+github.com/kcp-dev/logicalcluster/v3 v3.0.5 h1:JbYakokb+5Uinz09oTXomSUJVQsqfxEvU4RyHUYxHOU=
+github.com/kcp-dev/logicalcluster/v3 v3.0.5/go.mod h1:EWBUBxdr49fUB1cLMO4nOdBWmYifLbP1LfoL20KkXYY=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -413,8 +425,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
-golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
+golang.org/x/net v0.36.0 h1:vWF2fRbw4qslQsQzgFqZff+BItCvGFQqKzKIzx1rmoA=
+golang.org/x/net v0.36.0/go.mod h1:bFmbeoIPfrw4sMHNhb4J9f6+tPziuGjq7Jk/38fxi1I=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -608,8 +620,6 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcp
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/cluster-api v1.9.5 h1:68164Q201Y5ANVkhyrOZenoMbfL2SEBjVYZs/ihhSro=
 sigs.k8s.io/cluster-api v1.9.5/go.mod h1:DyqyZ4jRvKGKewDRn1Q4OCHaVjsdTogymbO6mrgHEDI=
-sigs.k8s.io/controller-runtime v0.20.3 h1:I6Ln8JfQjHH7JbtCD2HCYHoIzajoRxPNuvhvcDbZgkI=
-sigs.k8s.io/controller-runtime v0.20.3/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -1,0 +1,107 @@
+package controller
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/kcp"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/gardener/cluster-api-provider-gardener/api/v1alpha1"
+)
+
+// ClusterController mocks the cluster-api Cluster controller.
+// This _ONLY_ works with the Gardener provider, as no dynamic watching is being done here.
+type ClusterController struct {
+	Client client.Client
+	Scheme *runtime.Scheme
+}
+
+func (r *ClusterController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := runtimelog.FromContext(ctx).WithValues("cluster-object", req.NamespacedName, "cluster", req.ClusterName)
+
+	log.Info("Getting Cluster")
+	cluster := v1beta1.Cluster{}
+	if err := r.Client.Get(ctx, req.NamespacedName, &cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("resource no longer exists")
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Mocking setting the Owner reference for GardenerShootControlPlanes
+	gscp := &v1alpha1.GardenerShootControlPlane{}
+	if err := r.Client.Get(ctx, client.ObjectKey{
+		Name:      cluster.Spec.ControlPlaneRef.Name,
+		Namespace: cluster.Spec.ControlPlaneRef.Namespace,
+	}, gscp); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("could not find respective GSCP. Requeueing.")
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if err := ensureOwnerRef(ctx, r.Client, gscp, &cluster); err != nil {
+		log.Error(err, "unable to ensure OwnerRef on GSCP")
+		return ctrl.Result{}, err
+	}
+
+	if gscp.Status.Initialized {
+		cluster.Status = v1beta1.ClusterStatus{
+			Phase:               string(v1beta1.ClusterPhaseProvisioned),
+			InfrastructureReady: true,
+			ControlPlaneReady:   true,
+			ObservedGeneration:  cluster.Generation,
+		}
+		if err := r.Client.Status().Update(ctx, &cluster); err != nil {
+			log.Error(err, "unable to update cluster status")
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func ensureOwnerRef(ctx context.Context, c client.Client, obj *v1alpha1.GardenerShootControlPlane, cluster *v1beta1.Cluster) error {
+	desiredOwnerRef := metav1.OwnerReference{
+		APIVersion: cluster.APIVersion,
+		Kind:       cluster.Kind,
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+	}
+
+	if util.HasExactOwnerRef(obj.GetOwnerReferences(), desiredOwnerRef) &&
+		obj.GetLabels()[v1beta1.ClusterNameLabel] == cluster.Name {
+		return nil
+	}
+
+	if err := controllerutil.SetControllerReference(cluster, obj, c.Scheme()); err != nil {
+		return err
+	}
+
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[v1beta1.ClusterNameLabel] = cluster.Name
+	obj.SetLabels(labels)
+
+	return c.Update(ctx, obj)
+}
+
+func (r *ClusterController) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1beta1.Cluster{}).
+		Named("cluster").
+		Owns(&v1alpha1.GardenerShootControlPlane{}).
+		Complete(kcp.WithClusterInContext(r))
+}

--- a/internal/controller/gardenershootcontrolplane_controller.go
+++ b/internal/controller/gardenershootcontrolplane_controller.go
@@ -269,7 +269,7 @@ func (r *GardenerShootControlPlaneReconciler) reconcileShootAccess(cpc ControlPl
 			ExpirationSeconds: ptr.To(int64(6000)),
 		},
 	}
-	if err := r.Client.SubResource("adminkubeconfig").Create(cpc.ctx, cpc.shoot, adminKubeconfigRequest); err != nil {
+	if err := r.GardenerClient.SubResource("adminkubeconfig").Create(cpc.ctx, cpc.shoot, adminKubeconfigRequest); err != nil {
 		return err
 	}
 

--- a/internal/controller/gardenershootcontrolplane_controller.go
+++ b/internal/controller/gardenershootcontrolplane_controller.go
@@ -368,7 +368,7 @@ func (r *GardenerShootControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager,
 				handler.EnqueueRequestsFromMapFunc(r.MapShootToControlPlaneObject),
 			),
 		).
-		Complete(r)
+		Complete(kcp.WithClusterInContext(r))
 }
 
 func (r *GardenerShootControlPlaneReconciler) MapShootToControlPlaneObject(ctx context.Context, obj client.Object) []reconcile.Request {

--- a/internal/controller/gardenershootcontrolplane_controller.go
+++ b/internal/controller/gardenershootcontrolplane_controller.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/kcp"
 	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -53,6 +54,7 @@ type GardenerShootControlPlaneReconciler struct {
 	Client         client.Client
 	GardenerClient client.Client
 	Scheme         *runtime.Scheme
+	IsKCP          bool
 }
 
 type ControlPlaneContext struct {
@@ -78,7 +80,7 @@ type ControlPlaneContext struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.2/pkg/reconcile
 func (r *GardenerShootControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := runtimelog.FromContext(ctx).WithValues("gardenershootcontrolplane", req.NamespacedName)
+	log := runtimelog.FromContext(ctx).WithValues("gardenershootcontrolplane", req.NamespacedName, "cluster", req.ClusterName)
 
 	cpc := ControlPlaneContext{
 		log: log,
@@ -107,6 +109,7 @@ func (r *GardenerShootControlPlaneReconciler) Reconcile(ctx context.Context, req
 	}
 
 	cpc.shoot = ShootFromControlPlane(cpc.shootControlPlane)
+	injectReferenceLabels(cpc.shoot, cpc.shootControlPlane, r.IsKCP, req.ClusterName)
 
 	// Handle deleted clusters
 	if !cpc.shootControlPlane.DeletionTimestamp.IsZero() {
@@ -346,6 +349,24 @@ func controlPlaneReady(shootStatus gardenercorev1beta1.ShootStatus) bool {
 	return false
 }
 
+func injectReferenceLabels(shoot *gardenercorev1beta1.Shoot, shootControlPlane *controlplanev1alpha1.GardenerShootControlPlane, isKCP bool, kcpClusterName string) {
+	labels := map[string]string{
+		controlplanev1alpha1.GSCPReferenceNameKey:      shootControlPlane.Name,
+		controlplanev1alpha1.GSCPReferenceNamespaceKey: shootControlPlane.Namespace,
+	}
+	if isKCP {
+		labels[controlplanev1alpha1.GSCPReferecenceClusterNameKey] = kcpClusterName
+	}
+
+	if shoot.Labels == nil {
+		shoot.Labels = labels
+	} else {
+		for k, v := range labels {
+			shoot.Labels[k] = v
+		}
+	}
+}
+
 func ShootFromControlPlane(shootControlPlane *controlplanev1alpha1.GardenerShootControlPlane) *gardenercorev1beta1.Shoot {
 	return &gardenercorev1beta1.Shoot{
 		ObjectMeta: metav1.ObjectMeta{
@@ -373,13 +394,38 @@ func (r *GardenerShootControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager,
 
 func (r *GardenerShootControlPlaneReconciler) MapShootToControlPlaneObject(ctx context.Context, obj client.Object) []reconcile.Request {
 	var (
-		log = runtimelog.FromContext(ctx).WithValues("shoot", client.ObjectKeyFromObject(obj))
-
-		controlPlaneList controlplanev1alpha1.GardenerShootControlPlaneList
+		log          = runtimelog.FromContext(ctx).WithValues("shoot", client.ObjectKeyFromObject(obj))
+		clusterName  string
+		controlPlane *controlplanev1alpha1.GardenerShootControlPlane
 	)
-	if err := r.Client.List(ctx, &controlPlaneList, client.MatchingFields{controlplanev1alpha1.ShootReferenceIndexKey: client.ObjectKeyFromObject(obj).String()}); err != nil || len(controlPlaneList.Items) != 1 {
-		log.Error(err, "Could not list control planes")
+	shoot, ok := obj.(*gardenercorev1beta1.Shoot)
+	if !ok {
+		log.Error(fmt.Errorf("could not assert object to Shoot"), "")
 		return nil
 	}
-	return []reconcile.Request{{NamespacedName: client.ObjectKeyFromObject(&controlPlaneList.Items[0])}}
+
+	namespace, ok := shoot.GetLabels()[controlplanev1alpha1.GSCPReferenceNamespaceKey]
+	if !ok {
+		log.Info("Could not find gscp namespace on label")
+		return nil
+	}
+
+	name, ok := shoot.GetLabels()[controlplanev1alpha1.GSCPReferenceNameKey]
+	if !ok {
+		log.Info("Could not find gscp name on label")
+	}
+	if r.IsKCP {
+		clusterName, ok = shoot.GetLabels()[controlplanev1alpha1.GSCPReferecenceClusterNameKey]
+		if !ok {
+			log.Info("Could not find gscp cluster on label")
+		}
+	}
+
+	controlPlane = &controlplanev1alpha1.GardenerShootControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	return []reconcile.Request{{NamespacedName: client.ObjectKeyFromObject(controlPlane), ClusterName: clusterName}}
 }

--- a/schemas/binding.yaml
+++ b/schemas/binding.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  name: controlplane.cluster.x-k8s.io
+spec:
+  reference:
+    export:
+      name: controlplane.cluster.x-k8s.io
+      path: "root:gardener"
+  permissionClaims:
+    - resource: "secrets"
+      all: true
+      group: ""
+      state: "Accepted"

--- a/schemas/gardener/apiexport-controlplane.cluster.x-k8s.io.yaml
+++ b/schemas/gardener/apiexport-controlplane.cluster.x-k8s.io.yaml
@@ -1,0 +1,22 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  creationTimestamp: null
+  name: controlplane.cluster.x-k8s.io
+spec:
+  latestResourceSchemas:
+  - v250401-cfe2a97.gardenershootcontrolplanes.controlplane.cluster.x-k8s.io
+  - v250401-e39f0c3.clusters.cluster.x-k8s.io
+  permissionClaims:
+    - group: ""
+      resource: "secrets"
+      all: true
+---
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExportEndpointSlice
+metadata:
+  name: controlplane.cluster.x-k8s.io
+spec:
+  export:
+    path: "root:gardener"
+    name: controlplane.cluster.x-k8s.io

--- a/schemas/gardener/apiexport-controlplane.cluster.x-k8s.io.yaml
+++ b/schemas/gardener/apiexport-controlplane.cluster.x-k8s.io.yaml
@@ -1,7 +1,6 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIExport
 metadata:
-  creationTimestamp: null
   name: controlplane.cluster.x-k8s.io
 spec:
   latestResourceSchemas:

--- a/schemas/gardener/apiresourceschema-clusters.cluster.x-k8s.io.yaml
+++ b/schemas/gardener/apiresourceschema-clusters.cluster.x-k8s.io.yaml
@@ -1,0 +1,1256 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v250401-e39f0c3.clusters.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    shortNames:
+    - cl
+    singular: cluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: ClusterClass of this Cluster, empty if the Cluster is not using
+        a ClusterClass
+      jsonPath: .spec.topology.class
+      name: ClusterClass
+      type: string
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of Cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this Cluster
+      jsonPath: .spec.topology.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      description: Cluster is the Schema for the clusters API.
+      properties:
+        apiVersion:
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+          type: string
+        kind:
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ClusterSpec defines the desired state of Cluster.
+          properties:
+            availabilityGates:
+              description: |-
+                availabilityGates specifies additional conditions to include when evaluating Cluster Available condition.
+
+                NOTE: this field is considered only for computing v1beta2 conditions.
+              items:
+                description: ClusterAvailabilityGate contains the type of a Cluster
+                  condition to be used as availability gate.
+                properties:
+                  conditionType:
+                    description: |-
+                      conditionType refers to a positive polarity condition (status true means good) with matching type in the Cluster's condition list.
+                      If the conditions doesn't exist, it will be treated as unknown.
+                      Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as availability gates.
+                    maxLength: 316
+                    minLength: 1
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    type: string
+                required:
+                - conditionType
+                type: object
+              maxItems: 32
+              type: array
+              x-kubernetes-list-map-keys:
+              - conditionType
+              x-kubernetes-list-type: map
+            clusterNetwork:
+              description: Cluster network configuration.
+              properties:
+                apiServerPort:
+                  description: |-
+                    apiServerPort specifies the port the API Server should bind to.
+                    Defaults to 6443.
+                  format: int32
+                  type: integer
+                pods:
+                  description: The network ranges from which Pod networks are allocated.
+                  properties:
+                    cidrBlocks:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - cidrBlocks
+                  type: object
+                serviceDomain:
+                  description: Domain name for services.
+                  type: string
+                services:
+                  description: The network ranges from which service VIPs are allocated.
+                  properties:
+                    cidrBlocks:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - cidrBlocks
+                  type: object
+              type: object
+            controlPlaneEndpoint:
+              description: controlPlaneEndpoint represents the endpoint used to communicate
+                with the control plane.
+              properties:
+                host:
+                  description: The hostname on which the API server is serving.
+                  type: string
+                port:
+                  description: The port on which the API server is serving.
+                  format: int32
+                  type: integer
+              required:
+              - host
+              - port
+              type: object
+            controlPlaneRef:
+              description: |-
+                controlPlaneRef is an optional reference to a provider-specific resource that holds
+                the details for provisioning the Control Plane for a Cluster.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: |-
+                    If referring to a piece of an object instead of an entire object, this string
+                    should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within a pod, this would take on a value like:
+                    "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]" (container with
+                    index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                    referencing a part of an object.
+                  type: string
+                kind:
+                  description: |-
+                    Kind of the referent.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                name:
+                  description: |-
+                    Name of the referent.
+                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace of the referent.
+                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                  type: string
+                resourceVersion:
+                  description: |-
+                    Specific resourceVersion to which this reference is made, if any.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                  type: string
+                uid:
+                  description: |-
+                    UID of the referent.
+                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                  type: string
+              type: object
+              x-kubernetes-map-type: atomic
+            infrastructureRef:
+              description: |-
+                infrastructureRef is a reference to a provider-specific resource that holds the details
+                for provisioning infrastructure for a cluster in said provider.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: |-
+                    If referring to a piece of an object instead of an entire object, this string
+                    should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within a pod, this would take on a value like:
+                    "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]" (container with
+                    index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                    referencing a part of an object.
+                  type: string
+                kind:
+                  description: |-
+                    Kind of the referent.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                  type: string
+                name:
+                  description: |-
+                    Name of the referent.
+                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace of the referent.
+                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                  type: string
+                resourceVersion:
+                  description: |-
+                    Specific resourceVersion to which this reference is made, if any.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                  type: string
+                uid:
+                  description: |-
+                    UID of the referent.
+                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                  type: string
+              type: object
+              x-kubernetes-map-type: atomic
+            paused:
+              description: paused can be used to prevent controllers from processing
+                the Cluster and all its associated objects.
+              type: boolean
+            topology:
+              description: |-
+                This encapsulates the topology for the cluster.
+                NOTE: It is required to enable the ClusterTopology
+                feature gate flag to activate managed topologies support;
+                this feature is highly experimental, and parts of it might still be not implemented.
+              properties:
+                class:
+                  description: The name of the ClusterClass object to create the topology.
+                  type: string
+                classNamespace:
+                  description: |-
+                    classNamespace is the namespace of the ClusterClass object to create the topology.
+                    If the namespace is empty or not set, it is defaulted to the namespace of the cluster object.
+                    Value must follow the DNS1123Subdomain syntax.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                controlPlane:
+                  description: controlPlane describes the cluster control plane.
+                  properties:
+                    machineHealthCheck:
+                      description: |-
+                        machineHealthCheck allows to enable, disable and override
+                        the MachineHealthCheck configuration in the ClusterClass for this control plane.
+                      properties:
+                        enable:
+                          description: |-
+                            enable controls if a MachineHealthCheck should be created for the target machines.
+
+                            If false: No MachineHealthCheck will be created.
+
+                            If not set(default): A MachineHealthCheck will be created if it is defined here or
+                             in the associated ClusterClass. If no MachineHealthCheck is defined then none will be created.
+
+                            If true: A MachineHealthCheck is guaranteed to be created. Cluster validation will
+                            block if `enable` is true and no MachineHealthCheck definition is available.
+                          type: boolean
+                        maxUnhealthy:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                            "selector" are not healthy.
+                          x-kubernetes-int-or-string: true
+                        nodeStartupTimeout:
+                          description: |-
+                            nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                            to consider a Machine unhealthy if a corresponding Node isn't associated
+                            through a `Spec.ProviderID` field.
+
+                            The duration set in this field is compared to the greatest of:
+                            - Cluster's infrastructure ready condition timestamp (if and when available)
+                            - Control Plane's initialized condition timestamp (if and when available)
+                            - Machine's infrastructure ready condition timestamp (if and when available)
+                            - Machine's metadata creation timestamp
+
+                            Defaults to 10 minutes.
+                            If you wish to disable this feature, set the value explicitly to 0.
+                          type: string
+                        remediationTemplate:
+                          description: |-
+                            remediationTemplate is a reference to a remediation template
+                            provided by an infrastructure provider.
+
+                            This field is completely optional, when filled, the MachineHealthCheck controller
+                            creates a new object from the template referenced and hands off remediation of the machine to
+                            a controller that lives outside of Cluster API.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: |-
+                                If referring to a piece of an object instead of an entire object, this string
+                                should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                For example, if the object reference is to a container within a pod, this would take on a value like:
+                                "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                the event) or if no container name is specified "spec.containers[2]" (container with
+                                index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                referencing a part of an object.
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the referent.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                              type: string
+                            resourceVersion:
+                              description: |-
+                                Specific resourceVersion to which this reference is made, if any.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                              type: string
+                            uid:
+                              description: |-
+                                UID of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        unhealthyConditions:
+                          description: |-
+                            unhealthyConditions contains a list of the conditions that determine
+                            whether a node is considered unhealthy. The conditions are combined in a
+                            logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                          items:
+                            description: |-
+                              UnhealthyCondition represents a Node condition type and value with a timeout
+                              specified as a duration.  When the named condition has been in the given
+                              status for at least the timeout value, a node is considered unhealthy.
+                            properties:
+                              status:
+                                minLength: 1
+                                type: string
+                              timeout:
+                                type: string
+                              type:
+                                minLength: 1
+                                type: string
+                            required:
+                            - status
+                            - timeout
+                            - type
+                            type: object
+                          type: array
+                        unhealthyRange:
+                          description: |-
+                            Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                            is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                            Eg. "[3-5]" - This means that remediation will be allowed only when:
+                            (a) there are at least 3 unhealthy machines (and)
+                            (b) there are at most 5 unhealthy machines
+                          pattern: ^\[[0-9]+-[0-9]+\]$
+                          type: string
+                      type: object
+                    metadata:
+                      description: |-
+                        metadata is the metadata applied to the ControlPlane and the Machines of the ControlPlane
+                        if the ControlPlaneTemplate referenced by the ClusterClass is machine based. If not, it
+                        is applied only to the ControlPlane.
+                        At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: http://kubernetes.io/docs/user-guide/labels
+                          type: object
+                      type: object
+                    nodeDeletionTimeout:
+                      description: |-
+                        nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                        hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                        Defaults to 10 seconds.
+                      type: string
+                    nodeDrainTimeout:
+                      description: |-
+                        nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                        The default value is 0, meaning that the node can be drained without any time limitations.
+                        NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                      type: string
+                    nodeVolumeDetachTimeout:
+                      description: |-
+                        nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                        to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                      type: string
+                    replicas:
+                      description: |-
+                        replicas is the number of control plane nodes.
+                        If the value is nil, the ControlPlane object is created without the number of Replicas
+                        and it's assumed that the control plane controller does not implement support for this field.
+                        When specified against a control plane provider that lacks support for this field, this value will be ignored.
+                      format: int32
+                      type: integer
+                    variables:
+                      description: variables can be used to customize the ControlPlane
+                        through patches.
+                      properties:
+                        overrides:
+                          description: overrides can be used to override Cluster level
+                            variables.
+                          items:
+                            description: |-
+                              ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                              Variable definition in the ClusterClass `status` variables.
+                            properties:
+                              definitionFrom:
+                                description: |-
+                                  definitionFrom specifies where the definition of this Variable is from.
+
+                                  Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                                type: string
+                              name:
+                                description: name of the variable.
+                                type: string
+                              value:
+                                description: |-
+                                  value of the variable.
+                                  Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                                  from the ClusterClass.
+                                  Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                                  hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                                  i.e. it is not possible to have no type field.
+                                  Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                                x-kubernetes-preserve-unknown-fields: true
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                      type: object
+                  type: object
+                rolloutAfter:
+                  description: |-
+                    rolloutAfter performs a rollout of the entire cluster one component at a time,
+                    control plane first and then machine deployments.
+
+                    Deprecated: This field has no function and is going to be removed in the next apiVersion.
+                  format: date-time
+                  type: string
+                variables:
+                  description: |-
+                    variables can be used to customize the Cluster through
+                    patches. They must comply to the corresponding
+                    VariableClasses defined in the ClusterClass.
+                  items:
+                    description: |-
+                      ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                      Variable definition in the ClusterClass `status` variables.
+                    properties:
+                      definitionFrom:
+                        description: |-
+                          definitionFrom specifies where the definition of this Variable is from.
+
+                          Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                        type: string
+                      name:
+                        description: name of the variable.
+                        type: string
+                      value:
+                        description: |-
+                          value of the variable.
+                          Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                          from the ClusterClass.
+                          Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                          hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                          i.e. it is not possible to have no type field.
+                          Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                version:
+                  description: The Kubernetes version of the cluster.
+                  type: string
+                workers:
+                  description: |-
+                    workers encapsulates the different constructs that form the worker nodes
+                    for the cluster.
+                  properties:
+                    machineDeployments:
+                      description: machineDeployments is a list of machine deployments
+                        in the cluster.
+                      items:
+                        description: |-
+                          MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology.
+                          This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.
+                        properties:
+                          class:
+                            description: |-
+                              class is the name of the MachineDeploymentClass used to create the set of worker nodes.
+                              This should match one of the deployment classes defined in the ClusterClass object
+                              mentioned in the `Cluster.Spec.Class` field.
+                            type: string
+                          failureDomain:
+                            description: |-
+                              failureDomain is the failure domain the machines will be created in.
+                              Must match a key in the FailureDomains map stored on the cluster object.
+                            type: string
+                          machineHealthCheck:
+                            description: |-
+                              machineHealthCheck allows to enable, disable and override
+                              the MachineHealthCheck configuration in the ClusterClass for this MachineDeployment.
+                            properties:
+                              enable:
+                                description: |-
+                                  enable controls if a MachineHealthCheck should be created for the target machines.
+
+                                  If false: No MachineHealthCheck will be created.
+
+                                  If not set(default): A MachineHealthCheck will be created if it is defined here or
+                                   in the associated ClusterClass. If no MachineHealthCheck is defined then none will be created.
+
+                                  If true: A MachineHealthCheck is guaranteed to be created. Cluster validation will
+                                  block if `enable` is true and no MachineHealthCheck definition is available.
+                                type: boolean
+                              maxUnhealthy:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                                  "selector" are not healthy.
+                                x-kubernetes-int-or-string: true
+                              nodeStartupTimeout:
+                                description: |-
+                                  nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                                  to consider a Machine unhealthy if a corresponding Node isn't associated
+                                  through a `Spec.ProviderID` field.
+
+                                  The duration set in this field is compared to the greatest of:
+                                  - Cluster's infrastructure ready condition timestamp (if and when available)
+                                  - Control Plane's initialized condition timestamp (if and when available)
+                                  - Machine's infrastructure ready condition timestamp (if and when available)
+                                  - Machine's metadata creation timestamp
+
+                                  Defaults to 10 minutes.
+                                  If you wish to disable this feature, set the value explicitly to 0.
+                                type: string
+                              remediationTemplate:
+                                description: |-
+                                  remediationTemplate is a reference to a remediation template
+                                  provided by an infrastructure provider.
+
+                                  This field is completely optional, when filled, the MachineHealthCheck controller
+                                  creates a new object from the template referenced and hands off remediation of the machine to
+                                  a controller that lives outside of Cluster API.
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent.
+                                    type: string
+                                  fieldPath:
+                                    description: |-
+                                      If referring to a piece of an object instead of an entire object, this string
+                                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                      the event) or if no container name is specified "spec.containers[2]" (container with
+                                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                      referencing a part of an object.
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the referent.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                    type: string
+                                  resourceVersion:
+                                    description: |-
+                                      Specific resourceVersion to which this reference is made, if any.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                    type: string
+                                  uid:
+                                    description: |-
+                                      UID of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              unhealthyConditions:
+                                description: |-
+                                  unhealthyConditions contains a list of the conditions that determine
+                                  whether a node is considered unhealthy. The conditions are combined in a
+                                  logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                                items:
+                                  description: |-
+                                    UnhealthyCondition represents a Node condition type and value with a timeout
+                                    specified as a duration.  When the named condition has been in the given
+                                    status for at least the timeout value, a node is considered unhealthy.
+                                  properties:
+                                    status:
+                                      minLength: 1
+                                      type: string
+                                    timeout:
+                                      type: string
+                                    type:
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - status
+                                  - timeout
+                                  - type
+                                  type: object
+                                type: array
+                              unhealthyRange:
+                                description: |-
+                                  Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                                  is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                                  Eg. "[3-5]" - This means that remediation will be allowed only when:
+                                  (a) there are at least 3 unhealthy machines (and)
+                                  (b) there are at most 5 unhealthy machines
+                                pattern: ^\[[0-9]+-[0-9]+\]$
+                                type: string
+                            type: object
+                          metadata:
+                            description: |-
+                              metadata is the metadata applied to the MachineDeployment and the machines of the MachineDeployment.
+                              At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  annotations is an unstructured key value map stored with a resource that may be
+                                  set by external tools to store and retrieve arbitrary metadata. They are not
+                                  queryable and should be preserved when modifying objects.
+                                  More info: http://kubernetes.io/docs/user-guide/annotations
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  Map of string keys and values that can be used to organize and categorize
+                                  (scope and select) objects. May match selectors of replication controllers
+                                  and services.
+                                  More info: http://kubernetes.io/docs/user-guide/labels
+                                type: object
+                            type: object
+                          minReadySeconds:
+                            description: |-
+                              Minimum number of seconds for which a newly created machine should
+                              be ready.
+                              Defaults to 0 (machine will be considered available as soon as it
+                              is ready)
+                            format: int32
+                            type: integer
+                          name:
+                            description: |-
+                              name is the unique identifier for this MachineDeploymentTopology.
+                              The value is used with other unique identifiers to create a MachineDeployment's Name
+                              (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
+                              the values are hashed together.
+                            type: string
+                          nodeDeletionTimeout:
+                            description: |-
+                              nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                              hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                              Defaults to 10 seconds.
+                            type: string
+                          nodeDrainTimeout:
+                            description: |-
+                              nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                              The default value is 0, meaning that the node can be drained without any time limitations.
+                              NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                            type: string
+                          nodeVolumeDetachTimeout:
+                            description: |-
+                              nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                              to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                            type: string
+                          replicas:
+                            description: |-
+                              replicas is the number of worker nodes belonging to this set.
+                              If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to 1)
+                              and it's assumed that an external entity (like cluster autoscaler) is responsible for the management
+                              of this value.
+                            format: int32
+                            type: integer
+                          strategy:
+                            description: |-
+                              The deployment strategy to use to replace existing machines with
+                              new ones.
+                            properties:
+                              remediation:
+                                description: |-
+                                  remediation controls the strategy of remediating unhealthy machines
+                                  and how remediating operations should occur during the lifecycle of the dependant MachineSets.
+                                properties:
+                                  maxInFlight:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      maxInFlight determines how many in flight remediations should happen at the same time.
+
+                                      Remediation only happens on the MachineSet with the most current revision, while
+                                      older MachineSets (usually present during rollout operations) aren't allowed to remediate.
+
+                                      Note: In general (independent of remediations), unhealthy machines are always
+                                      prioritized during scale down operations over healthy ones.
+
+                                      MaxInFlight can be set to a fixed number or a percentage.
+                                      Example: when this is set to 20%, the MachineSet controller deletes at most 20% of
+                                      the desired replicas.
+
+                                      If not set, remediation is limited to all machines (bounded by replicas)
+                                      under the active MachineSet's management.
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              rollingUpdate:
+                                description: |-
+                                  Rolling update config params. Present only if
+                                  MachineDeploymentStrategyType = RollingUpdate.
+                                properties:
+                                  deletePolicy:
+                                    description: |-
+                                      deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
+                                      Valid values are "Random, "Newest", "Oldest"
+                                      When no value is supplied, the default DeletePolicy of MachineSet is used
+                                    enum:
+                                    - Random
+                                    - Newest
+                                    - Oldest
+                                    type: string
+                                  maxSurge:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      The maximum number of machines that can be scheduled above the
+                                      desired number of machines.
+                                      Value can be an absolute number (ex: 5) or a percentage of
+                                      desired machines (ex: 10%).
+                                      This can not be 0 if MaxUnavailable is 0.
+                                      Absolute number is calculated from percentage by rounding up.
+                                      Defaults to 1.
+                                      Example: when this is set to 30%, the new MachineSet can be scaled
+                                      up immediately when the rolling update starts, such that the total
+                                      number of old and new machines do not exceed 130% of desired
+                                      machines. Once old machines have been killed, new MachineSet can
+                                      be scaled up further, ensuring that total number of machines running
+                                      at any time during the update is at most 130% of desired machines.
+                                    x-kubernetes-int-or-string: true
+                                  maxUnavailable:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      The maximum number of machines that can be unavailable during the update.
+                                      Value can be an absolute number (ex: 5) or a percentage of desired
+                                      machines (ex: 10%).
+                                      Absolute number is calculated from percentage by rounding down.
+                                      This can not be 0 if MaxSurge is 0.
+                                      Defaults to 0.
+                                      Example: when this is set to 30%, the old MachineSet can be scaled
+                                      down to 70% of desired machines immediately when the rolling update
+                                      starts. Once new machines are ready, old MachineSet can be scaled
+                                      down further, followed by scaling up the new MachineSet, ensuring
+                                      that the total number of machines available at all times
+                                      during the update is at least 70% of desired machines.
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              type:
+                                description: |-
+                                  type of deployment. Allowed values are RollingUpdate and OnDelete.
+                                  The default is RollingUpdate.
+                                enum:
+                                - RollingUpdate
+                                - OnDelete
+                                type: string
+                            type: object
+                          variables:
+                            description: variables can be used to customize the MachineDeployment
+                              through patches.
+                            properties:
+                              overrides:
+                                description: overrides can be used to override Cluster
+                                  level variables.
+                                items:
+                                  description: |-
+                                    ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                                    Variable definition in the ClusterClass `status` variables.
+                                  properties:
+                                    definitionFrom:
+                                      description: |-
+                                        definitionFrom specifies where the definition of this Variable is from.
+
+                                        Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                                      type: string
+                                    name:
+                                      description: name of the variable.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        value of the variable.
+                                        Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                                        from the ClusterClass.
+                                        Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                                        hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                                        i.e. it is not possible to have no type field.
+                                        Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                        required:
+                        - class
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    machinePools:
+                      description: machinePools is a list of machine pools in the
+                        cluster.
+                      items:
+                        description: |-
+                          MachinePoolTopology specifies the different parameters for a pool of worker nodes in the topology.
+                          This pool of nodes is managed by a MachinePool object whose lifecycle is managed by the Cluster controller.
+                        properties:
+                          class:
+                            description: |-
+                              class is the name of the MachinePoolClass used to create the pool of worker nodes.
+                              This should match one of the deployment classes defined in the ClusterClass object
+                              mentioned in the `Cluster.Spec.Class` field.
+                            type: string
+                          failureDomains:
+                            description: |-
+                              failureDomains is the list of failure domains the machine pool will be created in.
+                              Must match a key in the FailureDomains map stored on the cluster object.
+                            items:
+                              type: string
+                            type: array
+                          metadata:
+                            description: |-
+                              metadata is the metadata applied to the MachinePool.
+                              At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  annotations is an unstructured key value map stored with a resource that may be
+                                  set by external tools to store and retrieve arbitrary metadata. They are not
+                                  queryable and should be preserved when modifying objects.
+                                  More info: http://kubernetes.io/docs/user-guide/annotations
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  Map of string keys and values that can be used to organize and categorize
+                                  (scope and select) objects. May match selectors of replication controllers
+                                  and services.
+                                  More info: http://kubernetes.io/docs/user-guide/labels
+                                type: object
+                            type: object
+                          minReadySeconds:
+                            description: |-
+                              Minimum number of seconds for which a newly created machine pool should
+                              be ready.
+                              Defaults to 0 (machine will be considered available as soon as it
+                              is ready)
+                            format: int32
+                            type: integer
+                          name:
+                            description: |-
+                              name is the unique identifier for this MachinePoolTopology.
+                              The value is used with other unique identifiers to create a MachinePool's Name
+                              (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
+                              the values are hashed together.
+                            type: string
+                          nodeDeletionTimeout:
+                            description: |-
+                              nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the MachinePool
+                              hosts after the MachinePool is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                              Defaults to 10 seconds.
+                            type: string
+                          nodeDrainTimeout:
+                            description: |-
+                              nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                              The default value is 0, meaning that the node can be drained without any time limitations.
+                              NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                            type: string
+                          nodeVolumeDetachTimeout:
+                            description: |-
+                              nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                              to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                            type: string
+                          replicas:
+                            description: |-
+                              replicas is the number of nodes belonging to this pool.
+                              If the value is nil, the MachinePool is created without the number of Replicas (defaulting to 1)
+                              and it's assumed that an external entity (like cluster autoscaler) is responsible for the management
+                              of this value.
+                            format: int32
+                            type: integer
+                          variables:
+                            description: variables can be used to customize the MachinePool
+                              through patches.
+                            properties:
+                              overrides:
+                                description: overrides can be used to override Cluster
+                                  level variables.
+                                items:
+                                  description: |-
+                                    ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                                    Variable definition in the ClusterClass `status` variables.
+                                  properties:
+                                    definitionFrom:
+                                      description: |-
+                                        definitionFrom specifies where the definition of this Variable is from.
+
+                                        Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                                      type: string
+                                    name:
+                                      description: name of the variable.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        value of the variable.
+                                        Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                                        from the ClusterClass.
+                                        Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                                        hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                                        i.e. it is not possible to have no type field.
+                                        Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                        required:
+                        - class
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  type: object
+              required:
+              - class
+              - version
+              type: object
+          type: object
+        status:
+          description: ClusterStatus defines the observed state of Cluster.
+          properties:
+            conditions:
+              description: conditions defines current service state of the cluster.
+              items:
+                description: Condition defines an observation of a Cluster API resource
+                  operational state.
+                properties:
+                  lastTransitionTime:
+                    description: |-
+                      Last time the condition transitioned from one status to another.
+                      This should be when the underlying condition changed. If that is not known, then using the time when
+                      the API field changed is acceptable.
+                    format: date-time
+                    type: string
+                  message:
+                    description: |-
+                      A human readable message indicating details about the transition.
+                      This field may be empty.
+                    type: string
+                  reason:
+                    description: |-
+                      The reason for the condition's last transition in CamelCase.
+                      The specific API may choose whether or not this field is considered a guaranteed API.
+                      This field may be empty.
+                    type: string
+                  severity:
+                    description: |-
+                      severity provides an explicit classification of Reason code, so the users or machines can immediately
+                      understand the current situation and act accordingly.
+                      The Severity field MUST be set only when Status=False.
+                    type: string
+                  status:
+                    description: status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: |-
+                      type of condition in CamelCase or in foo.example.com/CamelCase.
+                      Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                      can be useful (see .node.status.conditions), the ability to deconflict is important.
+                    type: string
+                required:
+                - lastTransitionTime
+                - status
+                - type
+                type: object
+              type: array
+            controlPlaneReady:
+              description: |-
+                controlPlaneReady denotes if the control plane became ready during initial provisioning
+                to receive requests.
+                NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                The value of this field is never updated after provisioning is completed. Please use conditions
+                to check the operational state of the control plane.
+              type: boolean
+            failureDomains:
+              additionalProperties:
+                description: |-
+                  FailureDomainSpec is the Schema for Cluster API failure domains.
+                  It allows controllers to understand how many failure domains a cluster can optionally span across.
+                properties:
+                  attributes:
+                    additionalProperties:
+                      type: string
+                    description: attributes is a free form map of attributes an infrastructure
+                      provider might use or require.
+                    type: object
+                  controlPlane:
+                    description: controlPlane determines if this failure domain is
+                      suitable for use by control plane machines.
+                    type: boolean
+                type: object
+              description: failureDomains is a slice of failure domain objects synced
+                from the infrastructure provider.
+              type: object
+            failureMessage:
+              description: |-
+                failureMessage indicates that there is a fatal problem reconciling the
+                state, and will be set to a descriptive error message.
+
+                Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+              type: string
+            failureReason:
+              description: |-
+                failureReason indicates that there is a fatal problem reconciling the
+                state, and will be set to a token value suitable for
+                programmatic interpretation.
+
+                Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+              type: string
+            infrastructureReady:
+              description: infrastructureReady is the state of the infrastructure
+                provider.
+              type: boolean
+            observedGeneration:
+              description: observedGeneration is the latest generation observed by
+                the controller.
+              format: int64
+              type: integer
+            phase:
+              description: |-
+                phase represents the current phase of cluster actuation.
+                E.g. Pending, Running, Terminating, Failed etc.
+              type: string
+            v1beta2:
+              description: v1beta2 groups all the fields that will be added or modified
+                in Cluster's status with the V1Beta2 version.
+              properties:
+                conditions:
+                  description: |-
+                    conditions represents the observations of a Cluster's current state.
+                    Known condition types are Available, InfrastructureReady, ControlPlaneInitialized, ControlPlaneAvailable, WorkersAvailable, MachinesReady
+                    MachinesUpToDate, RemoteConnectionProbe, ScalingUp, ScalingDown, Remediating, Deleting, Paused.
+                    Additionally, a TopologyReconciled condition will be added in case the Cluster is referencing a ClusterClass / defining a managed Topology.
+                  items:
+                    description: Condition contains details for one aspect of the
+                      current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False,
+                          Unknown.
+                        enum:
+                        - "True"
+                        - "False"
+                        - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                    - lastTransitionTime
+                    - message
+                    - reason
+                    - status
+                    - type
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - type
+                  x-kubernetes-list-type: map
+                controlPlane:
+                  description: controlPlane groups all the observations about Cluster's
+                    ControlPlane current state.
+                  properties:
+                    availableReplicas:
+                      description: availableReplicas is the total number of available
+                        control plane machines in this cluster. A machine is considered
+                        available when Machine's Available condition is true.
+                      format: int32
+                      type: integer
+                    desiredReplicas:
+                      description: desiredReplicas is the total number of desired
+                        control plane machines in this cluster.
+                      format: int32
+                      type: integer
+                    readyReplicas:
+                      description: readyReplicas is the total number of ready control
+                        plane machines in this cluster. A machine is considered ready
+                        when Machine's Ready condition is true.
+                      format: int32
+                      type: integer
+                    replicas:
+                      description: |-
+                        replicas is the total number of control plane machines in this cluster.
+                        NOTE: replicas also includes machines still being provisioned or being deleted.
+                      format: int32
+                      type: integer
+                    upToDateReplicas:
+                      description: upToDateReplicas is the number of up-to-date control
+                        plane machines in this cluster. A machine is considered up-to-date
+                        when Machine's UpToDate condition is true.
+                      format: int32
+                      type: integer
+                  type: object
+                workers:
+                  description: workers groups all the observations about Cluster's
+                    Workers current state.
+                  properties:
+                    availableReplicas:
+                      description: availableReplicas is the total number of available
+                        worker machines in this cluster. A machine is considered available
+                        when Machine's Available condition is true.
+                      format: int32
+                      type: integer
+                    desiredReplicas:
+                      description: desiredReplicas is the total number of desired
+                        worker machines in this cluster.
+                      format: int32
+                      type: integer
+                    readyReplicas:
+                      description: readyReplicas is the total number of ready worker
+                        machines in this cluster. A machine is considered ready when
+                        Machine's Ready condition is true.
+                      format: int32
+                      type: integer
+                    replicas:
+                      description: |-
+                        replicas is the total number of worker machines in this cluster.
+                        NOTE: replicas also includes machines still being provisioned or being deleted.
+                      format: int32
+                      type: integer
+                    upToDateReplicas:
+                      description: upToDateReplicas is the number of up-to-date worker
+                        machines in this cluster. A machine is considered up-to-date
+                        when Machine's UpToDate condition is true.
+                      format: int32
+                      type: integer
+                  type: object
+              type: object
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/schemas/gardener/apiresourceschema-clusters.cluster.x-k8s.io.yaml
+++ b/schemas/gardener/apiresourceschema-clusters.cluster.x-k8s.io.yaml
@@ -1,7 +1,6 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  creationTimestamp: null
   name: v250401-e39f0c3.clusters.cluster.x-k8s.io
 spec:
   group: cluster.x-k8s.io

--- a/schemas/gardener/apiresourceschema-gardenershootcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/schemas/gardener/apiresourceschema-gardenershootcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -1,0 +1,3014 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v250401-cfe2a97.gardenershootcontrolplanes.controlplane.cluster.x-k8s.io
+spec:
+  group: controlplane.cluster.x-k8s.io
+  names:
+    kind: GardenerShootControlPlane
+    listKind: GardenerShootControlPlaneList
+    plural: gardenershootcontrolplanes
+    shortNames:
+    - gscp
+    singular: gardenershootcontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      description: GardenerShootControlPlane represents a Shoot cluster.
+      properties:
+        apiVersion:
+          description: |-
+            APIVersion defines the versioned schema of this representation of an object.
+            Servers should convert recognized schemas to the latest internal value, and
+            may reject unrecognized values.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+          type: string
+        kind:
+          description: |-
+            Kind is a string value representing the REST resource this object represents.
+            Servers may infer this from the endpoint the client submits requests to.
+            Cannot be updated.
+            In CamelCase.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: |-
+            Specification of the Shoot cluster.
+            If the object's deletion timestamp is set, this field is immutable.
+          properties:
+            controlPlaneEndpoint:
+              description: ControlPlaneEndpoint represents the endpoint used to communicate
+                with the control plane.
+              properties:
+                host:
+                  description: The hostname on which the API server is serving.
+                  type: string
+                port:
+                  description: The port on which the API server is serving.
+                  format: int32
+                  type: integer
+              required:
+              - host
+              - port
+              type: object
+            projectNamespace:
+              description: |-
+                ProjectNamespace is the namespace in which the Shoot should be placed in.
+                This has to be a valid project namespace within the Gardener cluster.
+                If not set, the namespace of this object will be used in the Gardener cluster.
+              type: string
+            shootSpec:
+              description: ShootSpec is the specification of the desired Shoot cluster.
+              properties:
+                accessRestrictions:
+                  description: AccessRestrictions describe a list of access restrictions
+                    for this shoot cluster.
+                  items:
+                    description: |-
+                      AccessRestrictionWithOptions describes an access restriction for a Kubernetes cluster (e.g., EU access-only) and
+                      allows to specify additional options.
+                    properties:
+                      name:
+                        description: Name is the name of the restriction.
+                        type: string
+                      options:
+                        additionalProperties:
+                          type: string
+                        description: Options is a map of additional options for the
+                          access restriction.
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                addons:
+                  description: Addons contains information about enabled/disabled
+                    addons and their configuration.
+                  properties:
+                    kubernetesDashboard:
+                      description: KubernetesDashboard holds configuration settings
+                        for the kubernetes dashboard addon.
+                      properties:
+                        authenticationMode:
+                          description: AuthenticationMode defines the authentication
+                            mode for the kubernetes-dashboard.
+                          type: string
+                        enabled:
+                          description: Enabled indicates whether the addon is enabled
+                            or not.
+                          type: boolean
+                      required:
+                      - enabled
+                      type: object
+                    nginxIngress:
+                      description: NginxIngress holds configuration settings for the
+                        nginx-ingress addon.
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Config contains custom configuration for the nginx-ingress-controller configuration.
+                            See https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options
+                          type: object
+                        enabled:
+                          description: Enabled indicates whether the addon is enabled
+                            or not.
+                          type: boolean
+                        externalTrafficPolicy:
+                          description: |-
+                            ExternalTrafficPolicy controls the `.spec.externalTrafficPolicy` value of the load balancer `Service`
+                            exposing the nginx-ingress. Defaults to `Cluster`.
+                          type: string
+                        loadBalancerSourceRanges:
+                          description: LoadBalancerSourceRanges is list of allowed
+                            IP sources for NginxIngress
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - enabled
+                      type: object
+                  type: object
+                cloudProfile:
+                  description: CloudProfile contains a reference to a CloudProfile
+                    or a NamespacedCloudProfile.
+                  properties:
+                    kind:
+                      description: Kind contains a CloudProfile kind.
+                      type: string
+                    name:
+                      description: Name contains the name of the referenced CloudProfile.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                cloudProfileName:
+                  description: |-
+                    CloudProfileName is a name of a CloudProfile object.
+                    Deprecated: This field will be removed in a future version of Gardener. Use `CloudProfile` instead.
+                    Until removed, this field is synced with the `CloudProfile` field.
+                  type: string
+                controlPlane:
+                  description: ControlPlane contains general settings for the control
+                    plane of the shoot.
+                  properties:
+                    highAvailability:
+                      description: |-
+                        HighAvailability holds the configuration settings for high availability of the
+                        control plane of a shoot.
+                      properties:
+                        failureTolerance:
+                          description: FailureTolerance holds information about failure
+                            tolerance level of a highly available resource.
+                          properties:
+                            type:
+                              description: Type specifies the type of failure that
+                                the highly available resource can tolerate
+                              type: string
+                          required:
+                          - type
+                          type: object
+                      required:
+                      - failureTolerance
+                      type: object
+                  type: object
+                credentialsBindingName:
+                  description: |-
+                    CredentialsBindingName is the name of a CredentialsBinding that has a reference to the provider credentials.
+                    The credentials will be used to create the shoot in the respective account. The field is mutually exclusive with SecretBindingName.
+                  type: string
+                dns:
+                  description: DNS contains information about the DNS settings of
+                    the Shoot.
+                  properties:
+                    domain:
+                      description: |-
+                        Domain is the external available domain of the Shoot cluster. This domain will be written into the
+                        kubeconfig that is handed out to end-users. This field is immutable.
+                      type: string
+                    providers:
+                      description: |-
+                        Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
+                        not a default domain is used.
+
+                        Deprecated: Configuring multiple DNS providers is deprecated and will be forbidden in a future release.
+                        Please use the DNS extension provider config (e.g. shoot-dns-service) for additional providers.
+                      items:
+                        description: DNSProvider contains information about a DNS
+                          provider.
+                        properties:
+                          domains:
+                            description: |-
+                              Domains contains information about which domains shall be included/excluded for this provider.
+
+                              Deprecated: This field is deprecated and will be removed in a future release.
+                              Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.
+                            properties:
+                              exclude:
+                                description: Exclude is a list of domains that shall
+                                  be excluded.
+                                items:
+                                  type: string
+                                type: array
+                              include:
+                                description: Include is a list of domains that shall
+                                  be included.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          primary:
+                            description: |-
+                              Primary indicates that this DNSProvider is used for shoot related domains.
+
+                              Deprecated: This field is deprecated and will be removed in a future release.
+                              Please use the DNS extension provider config (e.g. shoot-dns-service) for additional and non-primary providers.
+                            type: boolean
+                          secretName:
+                            description: |-
+                              SecretName is a name of a secret containing credentials for the stated domain and the
+                              provider. When not specified, the Gardener will use the cloud provider credentials referenced
+                              by the Shoot and try to find respective credentials there (primary provider only). Specifying this field may override
+                              this behavior, i.e. forcing the Gardener to only look into the given secret.
+                            type: string
+                          type:
+                            description: Type is the DNS provider type.
+                            type: string
+                          zones:
+                            description: |-
+                              Zones contains information about which hosted zones shall be included/excluded for this provider.
+
+                              Deprecated: This field is deprecated and will be removed in a future release.
+                              Please use the DNS extension provider config (e.g. shoot-dns-service) for additional configuration.
+                            properties:
+                              exclude:
+                                description: Exclude is a list of domains that shall
+                                  be excluded.
+                                items:
+                                  type: string
+                                type: array
+                              include:
+                                description: Include is a list of domains that shall
+                                  be included.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                exposureClassName:
+                  description: |-
+                    ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
+                    This field is immutable.
+                  type: string
+                extensions:
+                  description: Extensions contain type and provider information for
+                    Shoot extensions.
+                  items:
+                    description: Extension contains type and provider information
+                      for Shoot extensions.
+                    properties:
+                      disabled:
+                        description: Disabled allows to disable extensions that were
+                          marked as 'globally enabled' by Gardener administrators.
+                        type: boolean
+                      providerConfig:
+                        description: ProviderConfig is the configuration passed to
+                          extension resource.
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      type:
+                        description: Type is the type of the extension resource.
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  type: array
+                hibernation:
+                  description: Hibernation contains information whether the Shoot
+                    is suspended or not.
+                  properties:
+                    enabled:
+                      description: |-
+                        Enabled specifies whether the Shoot needs to be hibernated or not. If it is true, the Shoot's desired state is to be hibernated.
+                        If it is false or nil, the Shoot's desired state is to be awakened.
+                      type: boolean
+                    schedules:
+                      description: Schedules determine the hibernation schedules.
+                      items:
+                        description: |-
+                          HibernationSchedule determines the hibernation schedule of a Shoot.
+                          A Shoot will be regularly hibernated at each start time and will be woken up at each end time.
+                          Start or End can be omitted, though at least one of each has to be specified.
+                        properties:
+                          end:
+                            description: End is a Cron spec at which time a Shoot
+                              will be woken up.
+                            type: string
+                          location:
+                            description: Location is the time location in which both
+                              start and shall be evaluated.
+                            type: string
+                          start:
+                            description: Start is a Cron spec at which time a Shoot
+                              will be hibernated.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                kubernetes:
+                  description: Kubernetes contains the version and configuration settings
+                    of the control plane components.
+                  properties:
+                    clusterAutoscaler:
+                      description: ClusterAutoscaler contains the configuration flags
+                        for the Kubernetes cluster autoscaler.
+                      properties:
+                        expander:
+                          description: |-
+                            Expander defines the algorithm to use during scale up (default: least-waste).
+                            See: https://github.com/gardener/autoscaler/blob/machine-controller-manager-provider/cluster-autoscaler/FAQ.md#what-are-expanders.
+                          type: string
+                        ignoreDaemonsetsUtilization:
+                          description: 'IgnoreDaemonsetsUtilization allows CA to ignore
+                            DaemonSet pods when calculating resource utilization for
+                            scaling down (default: false).'
+                          type: boolean
+                        ignoreTaints:
+                          description: |-
+                            IgnoreTaints specifies a list of taint keys to ignore in node templates when considering to scale a node group.
+                            Deprecated: Ignore taints are deprecated as of K8S 1.29 and treated as startup taints
+                          items:
+                            type: string
+                          type: array
+                        maxEmptyBulkDelete:
+                          description: 'MaxEmptyBulkDelete specifies the maximum number
+                            of empty nodes that can be deleted at the same time (default:
+                            10).'
+                          format: int32
+                          type: integer
+                        maxGracefulTerminationSeconds:
+                          description: 'MaxGracefulTerminationSeconds is the number
+                            of seconds CA waits for pod termination when trying to
+                            scale down a node (default: 600).'
+                          format: int32
+                          type: integer
+                        maxNodeProvisionTime:
+                          description: 'MaxNodeProvisionTime defines how long CA waits
+                            for node to be provisioned (default: 20 mins).'
+                          type: string
+                        newPodScaleUpDelay:
+                          description: 'NewPodScaleUpDelay specifies how long CA should
+                            ignore newly created pods before they have to be considered
+                            for scale-up (default: 0s).'
+                          type: string
+                        scaleDownDelayAfterAdd:
+                          description: 'ScaleDownDelayAfterAdd defines how long after
+                            scale up that scale down evaluation resumes (default:
+                            1 hour).'
+                          type: string
+                        scaleDownDelayAfterDelete:
+                          description: 'ScaleDownDelayAfterDelete how long after node
+                            deletion that scale down evaluation resumes, defaults
+                            to scanInterval (default: 0 secs).'
+                          type: string
+                        scaleDownDelayAfterFailure:
+                          description: 'ScaleDownDelayAfterFailure how long after
+                            scale down failure that scale down evaluation resumes
+                            (default: 3 mins).'
+                          type: string
+                        scaleDownUnneededTime:
+                          description: 'ScaleDownUnneededTime defines how long a node
+                            should be unneeded before it is eligible for scale down
+                            (default: 30 mins).'
+                          type: string
+                        scaleDownUtilizationThreshold:
+                          description: 'ScaleDownUtilizationThreshold defines the
+                            threshold in fraction (0.0 - 1.0) under which a node is
+                            being removed (default: 0.5).'
+                          type: number
+                        scanInterval:
+                          description: 'ScanInterval how often cluster is reevaluated
+                            for scale up or down (default: 10 secs).'
+                          type: string
+                        startupTaints:
+                          description: |-
+                            StartupTaints specifies a list of taint keys to ignore in node templates when considering to scale a node group.
+                            Cluster Autoscaler treats nodes tainted with startup taints as unready, but taken into account during scale up logic, assuming they will become ready shortly.
+                          items:
+                            type: string
+                          type: array
+                        statusTaints:
+                          description: |-
+                            StatusTaints specifies a list of taint keys to ignore in node templates when considering to scale a node group.
+                            Cluster Autoscaler internally treats nodes tainted with status taints as ready, but filtered out during scale up logic.
+                          items:
+                            type: string
+                          type: array
+                        verbosity:
+                          description: 'Verbosity allows CA to modify its log level
+                            (default: 2).'
+                          format: int32
+                          type: integer
+                      type: object
+                    enableStaticTokenKubeconfig:
+                      description: |-
+                        EnableStaticTokenKubeconfig indicates whether static token kubeconfig secret will be created for the Shoot cluster.
+                        Setting this field to true is not supported.
+
+                        Deprecated: This field is deprecated and will be removed in gardener v1.120
+                      type: boolean
+                    etcd:
+                      description: ETCD contains configuration for etcds of the shoot
+                        cluster.
+                      properties:
+                        events:
+                          description: Events contains configuration for the events
+                            etcd.
+                          properties:
+                            autoscaling:
+                              description: Autoscaling contains auto-scaling configuration
+                                options for etcd.
+                              properties:
+                                minAllowed:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    MinAllowed configures the minimum allowed resource requests for vertical pod autoscaling..
+                                    Configuration of minAllowed resources is an advanced feature that can help clusters to overcome scale-up delays.
+                                    Default values are not applied to this field.
+                                  type: object
+                              required:
+                              - minAllowed
+                              type: object
+                          type: object
+                        main:
+                          description: Main contains configuration for the main etcd.
+                          properties:
+                            autoscaling:
+                              description: Autoscaling contains auto-scaling configuration
+                                options for etcd.
+                              properties:
+                                minAllowed:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    MinAllowed configures the minimum allowed resource requests for vertical pod autoscaling..
+                                    Configuration of minAllowed resources is an advanced feature that can help clusters to overcome scale-up delays.
+                                    Default values are not applied to this field.
+                                  type: object
+                              required:
+                              - minAllowed
+                              type: object
+                          type: object
+                      type: object
+                    kubeAPIServer:
+                      description: KubeAPIServer contains configuration settings for
+                        the kube-apiserver.
+                      properties:
+                        admissionPlugins:
+                          description: |-
+                            AdmissionPlugins contains the list of user-defined admission plugins (additional to those managed by Gardener), and, if desired, the corresponding
+                            configuration.
+                          items:
+                            description: AdmissionPlugin contains information about
+                              a specific admission plugin and its corresponding configuration.
+                            properties:
+                              config:
+                                description: Config is the configuration of the plugin.
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              disabled:
+                                description: Disabled specifies whether this plugin
+                                  should be disabled.
+                                type: boolean
+                              kubeconfigSecretName:
+                                description: KubeconfigSecretName specifies the name
+                                  of a secret containing the kubeconfig for this admission
+                                  plugin.
+                                type: string
+                              name:
+                                description: Name is the name of the plugin.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        apiAudiences:
+                          description: |-
+                            APIAudiences are the identifiers of the API. The service account token authenticator will
+                            validate that tokens used against the API are bound to at least one of these audiences.
+                            Defaults to ["kubernetes"].
+                          items:
+                            type: string
+                          type: array
+                        auditConfig:
+                          description: AuditConfig contains configuration settings
+                            for the audit of the kube-apiserver.
+                          properties:
+                            auditPolicy:
+                              description: AuditPolicy contains configuration settings
+                                for audit policy of the kube-apiserver.
+                              properties:
+                                configMapRef:
+                                  description: |-
+                                    ConfigMapRef is a reference to a ConfigMap object in the same namespace,
+                                    which contains the audit policy for the kube-apiserver.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
+                        autoscaling:
+                          description: Autoscaling contains auto-scaling configuration
+                            options for the kube-apiserver.
+                          properties:
+                            minAllowed:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                MinAllowed configures the minimum allowed resource requests for vertical pod autoscaling..
+                                Configuration of minAllowed resources is an advanced feature that can help clusters to overcome scale-up delays.
+                                Default values are not applied to this field.
+                              type: object
+                          required:
+                          - minAllowed
+                          type: object
+                        defaultNotReadyTolerationSeconds:
+                          description: |-
+                            DefaultNotReadyTolerationSeconds indicates the tolerationSeconds of the toleration for notReady:NoExecute
+                            that is added by default to every pod that does not already have such a toleration (flag `--default-not-ready-toleration-seconds`).
+                            The field has effect only when the `DefaultTolerationSeconds` admission plugin is enabled.
+                            Defaults to 300.
+                          format: int64
+                          type: integer
+                        defaultUnreachableTolerationSeconds:
+                          description: |-
+                            DefaultUnreachableTolerationSeconds indicates the tolerationSeconds of the toleration for unreachable:NoExecute
+                            that is added by default to every pod that does not already have such a toleration (flag `--default-unreachable-toleration-seconds`).
+                            The field has effect only when the `DefaultTolerationSeconds` admission plugin is enabled.
+                            Defaults to 300.
+                          format: int64
+                          type: integer
+                        enableAnonymousAuthentication:
+                          description: |-
+                            EnableAnonymousAuthentication defines whether anonymous requests to the secure port
+                            of the API server should be allowed (flag `--anonymous-auth`).
+                            See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+                          type: boolean
+                        encryptionConfig:
+                          description: EncryptionConfig contains customizable encryption
+                            configuration of the Kube API server.
+                          properties:
+                            resources:
+                              description: |-
+                                Resources contains the list of resources that shall be encrypted in addition to secrets.
+                                Each item is a Kubernetes resource name in plural (resource or resource.group) that should be encrypted.
+                                Wildcards are not supported for now.
+                                See https://github.com/gardener/gardener/blob/master/docs/usage/security/etcd_encryption_config.md for more details.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - resources
+                          type: object
+                        eventTTL:
+                          description: |-
+                            EventTTL controls the amount of time to retain events.
+                            Defaults to 1h.
+                          type: string
+                        featureGates:
+                          additionalProperties:
+                            type: boolean
+                          description: FeatureGates contains information about enabled
+                            feature gates.
+                          type: object
+                        logging:
+                          description: Logging contains configuration for the log
+                            level and HTTP access logs.
+                          properties:
+                            httpAccessVerbosity:
+                              description: HTTPAccessVerbosity is the kube-apiserver
+                                access logs level
+                              format: int32
+                              type: integer
+                            verbosity:
+                              description: |-
+                                Verbosity is the kube-apiserver log verbosity level
+                                Defaults to 2.
+                              format: int32
+                              type: integer
+                          type: object
+                        oidcConfig:
+                          description: |-
+                            OIDCConfig contains configuration settings for the OIDC provider.
+
+                            Deprecated: This field is deprecated and will be forbidden starting from Kubernetes 1.32.
+                            Please configure and use structured authentication instead of oidc flags.
+                            For more information check https://github.com/gardener/gardener/issues/9858
+                          properties:
+                            caBundle:
+                              description: If set, the OpenID server's certificate
+                                will be verified by one of the authorities in the
+                                oidc-ca-file, otherwise the host's root CA set will
+                                be used.
+                              type: string
+                            clientAuthentication:
+                              description: |-
+                                ClientAuthentication can optionally contain client configuration used for kubeconfig generation.
+
+                                Deprecated: This field has no implemented use and will be forbidden starting from Kubernetes 1.31.
+                                It's use was planned for genereting OIDC kubeconfig https://github.com/gardener/gardener/issues/1433
+                              properties:
+                                extraConfig:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    Extra configuration added to kubeconfig's auth-provider.
+                                    Must not be any of idp-issuer-url, client-id, client-secret, idp-certificate-authority, idp-certificate-authority-data, id-token or refresh-token
+                                  type: object
+                                secret:
+                                  description: The client Secret for the OpenID Connect
+                                    client.
+                                  type: string
+                              type: object
+                            clientID:
+                              description: The client ID for the OpenID Connect client,
+                                must be set.
+                              type: string
+                            groupsClaim:
+                              description: If provided, the name of a custom OpenID
+                                Connect claim for specifying user groups. The claim
+                                value is expected to be a string or array of strings.
+                                This flag is experimental, please see the authentication
+                                documentation for further details.
+                              type: string
+                            groupsPrefix:
+                              description: If provided, all groups will be prefixed
+                                with this value to prevent conflicts with other authentication
+                                strategies.
+                              type: string
+                            issuerURL:
+                              description: The URL of the OpenID issuer, only HTTPS
+                                scheme will be accepted. Used to verify the OIDC JSON
+                                Web Token (JWT).
+                              type: string
+                            requiredClaims:
+                              additionalProperties:
+                                type: string
+                              description: key=value pairs that describes a required
+                                claim in the ID Token. If set, the claim is verified
+                                to be present in the ID Token with a matching value.
+                              type: object
+                            signingAlgs:
+                              description: List of allowed JOSE asymmetric signing
+                                algorithms. JWTs with a 'alg' header value not in
+                                this list will be rejected. Values are defined by
+                                RFC 7518 https://tools.ietf.org/html/rfc7518#section-3.1
+                              items:
+                                type: string
+                              type: array
+                            usernameClaim:
+                              description: The OpenID claim to use as the user name.
+                                Note that claims other than the default ('sub') is
+                                not guaranteed to be unique and immutable. This flag
+                                is experimental, please see the authentication documentation
+                                for further details. (default "sub")
+                              type: string
+                            usernamePrefix:
+                              description: If provided, all usernames will be prefixed
+                                with this value. If not provided, username claims
+                                other than 'email' are prefixed by the issuer URL
+                                to avoid clashes. To skip any prefixing, provide the
+                                value '-'.
+                              type: string
+                          type: object
+                        requests:
+                          description: Requests contains configuration for request-specific
+                            settings for the kube-apiserver.
+                          properties:
+                            maxMutatingInflight:
+                              description: |-
+                                MaxMutatingInflight is the maximum number of mutating requests in flight at a given time. When the server
+                                exceeds this, it rejects requests.
+                              format: int32
+                              type: integer
+                            maxNonMutatingInflight:
+                              description: |-
+                                MaxNonMutatingInflight is the maximum number of non-mutating requests in flight at a given time. When the server
+                                exceeds this, it rejects requests.
+                              format: int32
+                              type: integer
+                          type: object
+                        runtimeConfig:
+                          additionalProperties:
+                            type: boolean
+                          description: RuntimeConfig contains information about enabled
+                            or disabled APIs.
+                          type: object
+                        serviceAccountConfig:
+                          description: |-
+                            ServiceAccountConfig contains configuration settings for the service account handling
+                            of the kube-apiserver.
+                          properties:
+                            acceptedIssuers:
+                              description: |-
+                                AcceptedIssuers is an additional set of issuers that are used to determine which service account tokens are accepted.
+                                These values are not used to generate new service account tokens. Only useful when service account tokens are also
+                                issued by another external system or a change of the current issuer that is used for generating tokens is being performed.
+                              items:
+                                type: string
+                              type: array
+                            extendTokenExpiration:
+                              description: |-
+                                ExtendTokenExpiration turns on projected service account expiration extension during token generation, which
+                                helps safe transition from legacy token to bound service account token feature. If this flag is enabled,
+                                admission injected tokens would be extended up to 1 year to prevent unexpected failure during transition,
+                                ignoring value of service-account-max-token-expiration.
+                              type: boolean
+                            issuer:
+                              description: |-
+                                Issuer is the identifier of the service account token issuer. The issuer will assert this
+                                identifier in "iss" claim of issued tokens. This value is used to generate new service account tokens.
+                                This value is a string or URI. Defaults to URI of the API server.
+                              type: string
+                            maxTokenExpiration:
+                              description: |-
+                                MaxTokenExpiration is the maximum validity duration of a token created by the service account token issuer. If an
+                                otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued
+                                with a validity duration of this value.
+                                This field must be within [30d,90d].
+                              type: string
+                          type: object
+                        structuredAuthentication:
+                          description: |-
+                            StructuredAuthentication contains configuration settings for structured authentication for the kube-apiserver.
+                            This field is only available for Kubernetes v1.30 or later.
+                          properties:
+                            configMapName:
+                              description: |-
+                                ConfigMapName is the name of the ConfigMap in the project namespace which contains AuthenticationConfiguration
+                                for the kube-apiserver.
+                              type: string
+                          required:
+                          - configMapName
+                          type: object
+                        structuredAuthorization:
+                          description: |-
+                            StructuredAuthorization contains configuration settings for structured authorization for the kube-apiserver.
+                            This field is only available for Kubernetes v1.30 or later.
+                          properties:
+                            configMapName:
+                              description: |-
+                                ConfigMapName is the name of the ConfigMap in the project namespace which contains AuthorizationConfiguration for
+                                the kube-apiserver.
+                              type: string
+                            kubeconfigs:
+                              description: Kubeconfigs is a list of references for
+                                kubeconfigs for the authorization webhooks.
+                              items:
+                                description: AuthorizerKubeconfigReference is a reference
+                                  for a kubeconfig for a authorization webhook.
+                                properties:
+                                  authorizerName:
+                                    description: AuthorizerName is the name of a webhook
+                                      authorizer.
+                                    type: string
+                                  secretName:
+                                    description: SecretName is the name of a secret
+                                      containing the kubeconfig.
+                                    type: string
+                                required:
+                                - authorizerName
+                                - secretName
+                                type: object
+                              type: array
+                          required:
+                          - configMapName
+                          - kubeconfigs
+                          type: object
+                        watchCacheSizes:
+                          description: |-
+                            WatchCacheSizes contains configuration of the API server's watch cache sizes.
+                            Configuring these flags might be useful for large-scale Shoot clusters with a lot of parallel update requests
+                            and a lot of watching controllers (e.g. large ManagedSeed clusters). When the API server's watch cache's
+                            capacity is too small to cope with the amount of update requests and watchers for a particular resource, it
+                            might happen that controller watches are permanently stopped with `too old resource version` errors.
+                            Starting from kubernetes v1.19, the API server's watch cache size is adapted dynamically and setting the watch
+                            cache size flags will have no effect, except when setting it to 0 (which disables the watch cache).
+                          properties:
+                            default:
+                              description: |-
+                                Default configures the default watch cache size of the kube-apiserver
+                                (flag `--default-watch-cache-size`, defaults to 100).
+                                See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+                              format: int32
+                              type: integer
+                            resources:
+                              description: |-
+                                Resources configures the watch cache size of the kube-apiserver per resource
+                                (flag `--watch-cache-sizes`).
+                                See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+                              items:
+                                description: ResourceWatchCacheSize contains configuration
+                                  of the API server's watch cache size for one specific
+                                  resource.
+                                properties:
+                                  apiGroup:
+                                    description: |-
+                                      APIGroup is the API group of the resource for which the watch cache size should be configured.
+                                      An unset value is used to specify the legacy core API (e.g. for `secrets`).
+                                    type: string
+                                  resource:
+                                    description: |-
+                                      Resource is the name of the resource for which the watch cache size should be configured
+                                      (in lowercase plural form, e.g. `secrets`).
+                                    type: string
+                                  size:
+                                    description: CacheSize specifies the watch cache
+                                      size that should be configured for the specified
+                                      resource.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - resource
+                                - size
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    kubeControllerManager:
+                      description: KubeControllerManager contains configuration settings
+                        for the kube-controller-manager.
+                      properties:
+                        featureGates:
+                          additionalProperties:
+                            type: boolean
+                          description: FeatureGates contains information about enabled
+                            feature gates.
+                          type: object
+                        horizontalPodAutoscaler:
+                          description: HorizontalPodAutoscalerConfig contains horizontal
+                            pod autoscaler configuration settings for the kube-controller-manager.
+                          properties:
+                            cpuInitializationPeriod:
+                              description: The period after which a ready pod transition
+                                is considered to be the first.
+                              type: string
+                            downscaleStabilization:
+                              description: The configurable window at which the controller
+                                will choose the highest recommendation for autoscaling.
+                              type: string
+                            initialReadinessDelay:
+                              description: The configurable period at which the horizontal
+                                pod autoscaler considers a Pod “not yet ready” given
+                                that it’s unready and it has  transitioned to unready
+                                during that time.
+                              type: string
+                            syncPeriod:
+                              description: The period for syncing the number of pods
+                                in horizontal pod autoscaler.
+                              type: string
+                            tolerance:
+                              description: The minimum change (from 1.0) in the desired-to-actual
+                                metrics ratio for the horizontal pod autoscaler to
+                                consider scaling.
+                              type: number
+                          type: object
+                        nodeCIDRMaskSize:
+                          description: NodeCIDRMaskSize defines the mask size for
+                            node cidr in cluster (default is 24). This field is immutable.
+                          format: int32
+                          type: integer
+                        nodeMonitorGracePeriod:
+                          description: NodeMonitorGracePeriod defines the grace period
+                            before an unresponsive node is marked unhealthy.
+                          type: string
+                        podEvictionTimeout:
+                          description: |-
+                            PodEvictionTimeout defines the grace period for deleting pods on failed nodes. Defaults to 2m.
+
+                            Deprecated: The corresponding kube-controller-manager flag `--pod-eviction-timeout` is deprecated
+                            in favor of the kube-apiserver flags `--default-not-ready-toleration-seconds` and `--default-unreachable-toleration-seconds`.
+                            The `--pod-eviction-timeout` flag does not have effect when the taint based eviction is enabled. The taint
+                            based eviction is beta (enabled by default) since Kubernetes 1.13 and GA since Kubernetes 1.18. Hence,
+                            instead of setting this field, set the `spec.kubernetes.kubeAPIServer.defaultNotReadyTolerationSeconds` and
+                            `spec.kubernetes.kubeAPIServer.defaultUnreachableTolerationSeconds`. This field will be removed in gardener v1.120.
+                          type: string
+                      type: object
+                    kubeProxy:
+                      description: KubeProxy contains configuration settings for the
+                        kube-proxy.
+                      properties:
+                        enabled:
+                          description: |-
+                            Enabled indicates whether kube-proxy should be deployed or not.
+                            Depending on the networking extensions switching kube-proxy off might be rejected. Consulting the respective documentation of the used networking extension is recommended before using this field.
+                            defaults to true if not specified.
+                          type: boolean
+                        featureGates:
+                          additionalProperties:
+                            type: boolean
+                          description: FeatureGates contains information about enabled
+                            feature gates.
+                          type: object
+                        mode:
+                          description: |-
+                            Mode specifies which proxy mode to use.
+                            defaults to IPTables.
+                          type: string
+                      type: object
+                    kubeScheduler:
+                      description: KubeScheduler contains configuration settings for
+                        the kube-scheduler.
+                      properties:
+                        featureGates:
+                          additionalProperties:
+                            type: boolean
+                          description: FeatureGates contains information about enabled
+                            feature gates.
+                          type: object
+                        kubeMaxPDVols:
+                          description: |-
+                            KubeMaxPDVols allows to configure the `KUBE_MAX_PD_VOLS` environment variable for the kube-scheduler.
+                            Please find more information here: https://kubernetes.io/docs/concepts/storage/storage-limits/#custom-limits
+                            Note that using this field is considered alpha-/experimental-level and is on your own risk. You should be aware
+                            of all the side-effects and consequences when changing it.
+                          type: string
+                        profile:
+                          description: |-
+                            Profile configures the scheduling profile for the cluster.
+                            If not specified, the used profile is "balanced" (provides the default kube-scheduler behavior).
+                          type: string
+                      type: object
+                    kubelet:
+                      description: Kubelet contains configuration settings for the
+                        kubelet.
+                      properties:
+                        containerLogMaxFiles:
+                          description: Maximum number of container log files that
+                            can be present for a container.
+                          format: int32
+                          type: integer
+                        containerLogMaxSize:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            A quantity defines the maximum size of the container log file before it is rotated. For example: "5Mi" or "256Ki".
+                            Default: 100Mi
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        cpuCFSQuota:
+                          description: CPUCFSQuota allows you to disable/enable CPU
+                            throttling for Pods.
+                          type: boolean
+                        cpuManagerPolicy:
+                          description: 'CPUManagerPolicy allows to set alternative
+                            CPU management policies (default: none).'
+                          type: string
+                        evictionHard:
+                          description: |-
+                            EvictionHard describes a set of eviction thresholds (e.g. memory.available<1Gi) that if met would trigger a Pod eviction.
+                            Default:
+                              memory.available:   "100Mi/1Gi/5%"
+                              nodefs.available:   "5%"
+                              nodefs.inodesFree:  "5%"
+                              imagefs.available:  "5%"
+                              imagefs.inodesFree: "5%"
+                          properties:
+                            imageFSAvailable:
+                              description: ImageFSAvailable is the threshold for the
+                                free disk space in the imagefs filesystem (docker
+                                images and container writable layers).
+                              type: string
+                            imageFSInodesFree:
+                              description: ImageFSInodesFree is the threshold for
+                                the available inodes in the imagefs filesystem.
+                              type: string
+                            memoryAvailable:
+                              description: MemoryAvailable is the threshold for the
+                                free memory on the host server.
+                              type: string
+                            nodeFSAvailable:
+                              description: NodeFSAvailable is the threshold for the
+                                free disk space in the nodefs filesystem (docker volumes,
+                                logs, etc).
+                              type: string
+                            nodeFSInodesFree:
+                              description: NodeFSInodesFree is the threshold for the
+                                available inodes in the nodefs filesystem.
+                              type: string
+                          type: object
+                        evictionMaxPodGracePeriod:
+                          description: |-
+                            EvictionMaxPodGracePeriod describes the maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.
+                            Default: 90
+                          format: int32
+                          type: integer
+                        evictionMinimumReclaim:
+                          description: |-
+                            EvictionMinimumReclaim configures the amount of resources below the configured eviction threshold that the kubelet attempts to reclaim whenever the kubelet observes resource pressure.
+                            Default: 0 for each resource
+                          properties:
+                            imageFSAvailable:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: ImageFSAvailable is the threshold for the
+                                disk space reclaim in the imagefs filesystem (docker
+                                images and container writable layers).
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            imageFSInodesFree:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: ImageFSInodesFree is the threshold for
+                                the inodes reclaim in the imagefs filesystem.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            memoryAvailable:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: MemoryAvailable is the threshold for the
+                                memory reclaim on the host server.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            nodeFSAvailable:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: NodeFSAvailable is the threshold for the
+                                disk space reclaim in the nodefs filesystem (docker
+                                volumes, logs, etc).
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            nodeFSInodesFree:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: NodeFSInodesFree is the threshold for the
+                                inodes reclaim in the nodefs filesystem.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        evictionPressureTransitionPeriod:
+                          description: |-
+                            EvictionPressureTransitionPeriod is the duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.
+                            Default: 4m0s
+                          type: string
+                        evictionSoft:
+                          description: |-
+                            EvictionSoft describes a set of eviction thresholds (e.g. memory.available<1.5Gi) that if met over a corresponding grace period would trigger a Pod eviction.
+                            Default:
+                              memory.available:   "200Mi/1.5Gi/10%"
+                              nodefs.available:   "10%"
+                              nodefs.inodesFree:  "10%"
+                              imagefs.available:  "10%"
+                              imagefs.inodesFree: "10%"
+                          properties:
+                            imageFSAvailable:
+                              description: ImageFSAvailable is the threshold for the
+                                free disk space in the imagefs filesystem (docker
+                                images and container writable layers).
+                              type: string
+                            imageFSInodesFree:
+                              description: ImageFSInodesFree is the threshold for
+                                the available inodes in the imagefs filesystem.
+                              type: string
+                            memoryAvailable:
+                              description: MemoryAvailable is the threshold for the
+                                free memory on the host server.
+                              type: string
+                            nodeFSAvailable:
+                              description: NodeFSAvailable is the threshold for the
+                                free disk space in the nodefs filesystem (docker volumes,
+                                logs, etc).
+                              type: string
+                            nodeFSInodesFree:
+                              description: NodeFSInodesFree is the threshold for the
+                                available inodes in the nodefs filesystem.
+                              type: string
+                          type: object
+                        evictionSoftGracePeriod:
+                          description: |-
+                            EvictionSoftGracePeriod describes a set of eviction grace periods (e.g. memory.available=1m30s) that correspond to how long a soft eviction threshold must hold before triggering a Pod eviction.
+                            Default:
+                              memory.available:   1m30s
+                              nodefs.available:   1m30s
+                              nodefs.inodesFree:  1m30s
+                              imagefs.available:  1m30s
+                              imagefs.inodesFree: 1m30s
+                          properties:
+                            imageFSAvailable:
+                              description: ImageFSAvailable is the grace period for
+                                the ImageFSAvailable eviction threshold.
+                              type: string
+                            imageFSInodesFree:
+                              description: ImageFSInodesFree is the grace period for
+                                the ImageFSInodesFree eviction threshold.
+                              type: string
+                            memoryAvailable:
+                              description: MemoryAvailable is the grace period for
+                                the MemoryAvailable eviction threshold.
+                              type: string
+                            nodeFSAvailable:
+                              description: NodeFSAvailable is the grace period for
+                                the NodeFSAvailable eviction threshold.
+                              type: string
+                            nodeFSInodesFree:
+                              description: NodeFSInodesFree is the grace period for
+                                the NodeFSInodesFree eviction threshold.
+                              type: string
+                          type: object
+                        failSwapOn:
+                          description: FailSwapOn makes the Kubelet fail to start
+                            if swap is enabled on the node. (default true).
+                          type: boolean
+                        featureGates:
+                          additionalProperties:
+                            type: boolean
+                          description: FeatureGates contains information about enabled
+                            feature gates.
+                          type: object
+                        imageGCHighThresholdPercent:
+                          description: |-
+                            ImageGCHighThresholdPercent describes the percent of the disk usage which triggers image garbage collection.
+                            Default: 50
+                          format: int32
+                          type: integer
+                        imageGCLowThresholdPercent:
+                          description: |-
+                            ImageGCLowThresholdPercent describes the percent of the disk to which garbage collection attempts to free.
+                            Default: 40
+                          format: int32
+                          type: integer
+                        kubeReserved:
+                          description: |-
+                            KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime).
+                            When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
+                            Default: cpu=80m,memory=1Gi,pid=20k
+                          properties:
+                            cpu:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: CPU is the reserved cpu.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            ephemeralStorage:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: EphemeralStorage is the reserved ephemeral-storage.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            memory:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Memory is the reserved memory.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            pid:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: PID is the reserved process-ids.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        maxPods:
+                          description: |-
+                            MaxPods is the maximum number of Pods that are allowed by the Kubelet.
+                            Default: 110
+                          format: int32
+                          type: integer
+                        memorySwap:
+                          description: MemorySwap configures swap memory available
+                            to container workloads.
+                          properties:
+                            swapBehavior:
+                              description: |-
+                                SwapBehavior configures swap memory available to container workloads. May be one of {"LimitedSwap", "UnlimitedSwap"}
+                                defaults to: LimitedSwap
+                              type: string
+                          type: object
+                        podPidsLimit:
+                          description: PodPIDsLimit is the maximum number of process
+                            IDs per pod allowed by the kubelet.
+                          format: int64
+                          type: integer
+                        protectKernelDefaults:
+                          description: |-
+                            ProtectKernelDefaults ensures that the kernel tunables are equal to the kubelet defaults.
+                            Defaults to true.
+                          type: boolean
+                        registryBurst:
+                          description: |-
+                            RegistryBurst is the maximum size of bursty pulls, temporarily allows pulls to burst to this number,
+                            while still not exceeding registryPullQPS. The value must not be a negative number.
+                            Only used if registryPullQPS is greater than 0.
+                            Default: 10
+                          format: int32
+                          type: integer
+                        registryPullQPS:
+                          description: |-
+                            RegistryPullQPS is the limit of registry pulls per second. The value must not be a negative number.
+                            Setting it to 0 means no limit.
+                            Default: 5
+                          format: int32
+                          type: integer
+                        seccompDefault:
+                          description: SeccompDefault enables the use of `RuntimeDefault`
+                            as the default seccomp profile for all workloads.
+                          type: boolean
+                        serializeImagePulls:
+                          description: |-
+                            SerializeImagePulls describes whether the images are pulled one at a time.
+                            Default: true
+                          type: boolean
+                        streamingConnectionIdleTimeout:
+                          description: |-
+                            StreamingConnectionIdleTimeout is the maximum time a streaming connection can be idle before the connection is automatically closed.
+                            This field cannot be set lower than "30s" or greater than "4h".
+                            Default: "5m".
+                          type: string
+                        systemReserved:
+                          description: |-
+                            SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).
+                            When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
+
+                            Deprecated: Separately configuring resource reservations for system processes is deprecated in Gardener and will be forbidden starting from Kubernetes 1.31.
+                            Please merge existing resource reservations into the kubeReserved field.
+                          properties:
+                            cpu:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: CPU is the reserved cpu.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            ephemeralStorage:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: EphemeralStorage is the reserved ephemeral-storage.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            memory:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Memory is the reserved memory.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            pid:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: PID is the reserved process-ids.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    version:
+                      description: |-
+                        Version is the semantic Kubernetes version to use for the Shoot cluster.
+                        Defaults to the highest supported minor and patch version given in the referenced cloud profile.
+                        The version can be omitted completely or partially specified, e.g. `<major>.<minor>`.
+                      type: string
+                    verticalPodAutoscaler:
+                      description: VerticalPodAutoscaler contains the configuration
+                        flags for the Kubernetes vertical pod autoscaler.
+                      properties:
+                        cpuHistogramDecayHalfLife:
+                          description: |-
+                            CPUHistogramDecayHalfLife is the amount of time it takes a historical CPU usage sample to lose half of its weight.
+                            (default: 24h)
+                          type: string
+                        enabled:
+                          description: Enabled specifies whether the Kubernetes VPA
+                            shall be enabled for the shoot cluster.
+                          type: boolean
+                        evictAfterOOMThreshold:
+                          description: |-
+                            EvictAfterOOMThreshold defines the threshold that will lead to pod eviction in case it OOMed in less than the given
+                            threshold since its start and if it has only one container (default: 10m0s).
+                          type: string
+                        evictionRateBurst:
+                          description: 'EvictionRateBurst defines the burst of pods
+                            that can be evicted (default: 1)'
+                          format: int32
+                          type: integer
+                        evictionRateLimit:
+                          description: |-
+                            EvictionRateLimit defines the number of pods that can be evicted per second. A rate limit set to 0 or -1 will
+                            disable the rate limiter (default: -1).
+                          type: number
+                        evictionTolerance:
+                          description: |-
+                            EvictionTolerance defines the fraction of replica count that can be evicted for update in case more than one
+                            pod can be evicted (default: 0.5).
+                          type: number
+                        memoryAggregationInterval:
+                          description: |-
+                            MemoryAggregationInterval is the length of a single interval, for which the peak memory usage is computed.
+                            (default: 24h)
+                          type: string
+                        memoryAggregationIntervalCount:
+                          description: |-
+                            MemoryAggregationIntervalCount is the number of consecutive memory-aggregation-intervals which make up the
+                            MemoryAggregationWindowLength which in turn is the period for memory usage aggregation by VPA. In other words,
+                            `MemoryAggregationWindowLength = memory-aggregation-interval * memory-aggregation-interval-count`.
+                            (default: 8)
+                          format: int64
+                          type: integer
+                        memoryHistogramDecayHalfLife:
+                          description: |-
+                            MemoryHistogramDecayHalfLife is the amount of time it takes a historical memory usage sample to lose half of its weight.
+                            (default: 24h)
+                          type: string
+                        recommendationLowerBoundCPUPercentile:
+                          description: |-
+                            RecommendationLowerBoundCPUPercentile is the usage percentile that will be used for the lower bound on CPU recommendation.
+                            (default: 0.5)
+                          type: number
+                        recommendationLowerBoundMemoryPercentile:
+                          description: |-
+                            RecommendationLowerBoundMemoryPercentile is the usage percentile that will be used for the lower bound on memory recommendation.
+                            (default: 0.5)
+                          type: number
+                        recommendationMarginFraction:
+                          description: |-
+                            RecommendationMarginFraction is the fraction of usage added as the safety margin to the recommended request
+                            (default: 0.15).
+                          type: number
+                        recommendationUpperBoundCPUPercentile:
+                          description: |-
+                            RecommendationUpperBoundCPUPercentile is the usage percentile that will be used for the upper bound on CPU recommendation.
+                            (default: 0.95)
+                          type: number
+                        recommendationUpperBoundMemoryPercentile:
+                          description: |-
+                            RecommendationUpperBoundMemoryPercentile is the usage percentile that will be used for the upper bound on memory recommendation.
+                            (default: 0.95)
+                          type: number
+                        recommenderInterval:
+                          description: 'RecommenderInterval is the interval how often
+                            metrics should be fetched (default: 1m0s).'
+                          type: string
+                        targetCPUPercentile:
+                          description: |-
+                            TargetCPUPercentile is the usage percentile that will be used as a base for CPU target recommendation.
+                            Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations.
+                            (default: 0.9)
+                          type: number
+                        targetMemoryPercentile:
+                          description: |-
+                            TargetMemoryPercentile is the usage percentile that will be used as a base for memory target recommendation.
+                            Doesn't affect memory lower bound nor memory upper bound.
+                            (default: 0.9)
+                          type: number
+                        updaterInterval:
+                          description: 'UpdaterInterval is the interval how often
+                            the updater should run (default: 1m0s).'
+                          type: string
+                      required:
+                      - enabled
+                      type: object
+                  type: object
+                maintenance:
+                  description: |-
+                    Maintenance contains information about the time window for maintenance operations and which
+                    operations should be performed.
+                  properties:
+                    autoUpdate:
+                      description: AutoUpdate contains information about which constraints
+                        should be automatically updated.
+                      properties:
+                        kubernetesVersion:
+                          description: 'KubernetesVersion indicates whether the patch
+                            Kubernetes version may be automatically updated (default:
+                            true).'
+                          type: boolean
+                        machineImageVersion:
+                          description: 'MachineImageVersion indicates whether the
+                            machine image version may be automatically updated (default:
+                            true).'
+                          type: boolean
+                      required:
+                      - kubernetesVersion
+                      type: object
+                    confineSpecUpdateRollout:
+                      description: |-
+                        ConfineSpecUpdateRollout prevents that changes/updates to the shoot specification will be rolled out immediately.
+                        Instead, they are rolled out during the shoot's maintenance time window. There is one exception that will trigger
+                        an immediate roll out which is changes to the Spec.Hibernation.Enabled field.
+                      type: boolean
+                    timeWindow:
+                      description: TimeWindow contains information about the time
+                        window for maintenance operations.
+                      properties:
+                        begin:
+                          description: |-
+                            Begin is the beginning of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
+                            If not present, a random value will be computed.
+                          pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]\+[0-1][0-4]00
+                          type: string
+                        end:
+                          description: |-
+                            End is the end of the time window in the format HHMMSS+ZONE, e.g. "220000+0100".
+                            If not present, the value will be computed based on the "Begin" value.
+                          pattern: ([0-1][0-9]|2[0-3])[0-5][0-9][0-5][0-9]\+[0-1][0-4]00
+                          type: string
+                      required:
+                      - begin
+                      - end
+                      type: object
+                  type: object
+                monitoring:
+                  description: Monitoring contains information about custom monitoring
+                    configurations for the shoot.
+                  properties:
+                    alerting:
+                      description: Alerting contains information about the alerting
+                        configuration for the shoot cluster.
+                      properties:
+                        emailReceivers:
+                          description: MonitoringEmailReceivers is a list of recipients
+                            for alerts
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                  type: object
+                networking:
+                  description: Networking contains information about cluster networking
+                    such as CNI Plugin type, CIDRs, ...etc.
+                  properties:
+                    ipFamilies:
+                      description: |-
+                        IPFamilies specifies the IP protocol versions to use for shoot networking. This field is immutable.
+                        See https://github.com/gardener/gardener/blob/master/docs/development/ipv6.md.
+                        Defaults to ["IPv4"].
+                      items:
+                        description: IPFamily is a type for specifying an IP protocol
+                          version to use in Gardener clusters.
+                        type: string
+                      type: array
+                    nodes:
+                      description: |-
+                        Nodes is the CIDR of the entire node network.
+                        This field is mutable.
+                      type: string
+                    pods:
+                      description: Pods is the CIDR of the pod network. This field
+                        is immutable.
+                      type: string
+                    providerConfig:
+                      description: ProviderConfig is the configuration passed to network
+                        resource.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    services:
+                      description: Services is the CIDR of the service network. This
+                        field is immutable.
+                      type: string
+                    type:
+                      description: Type identifies the type of the networking plugin.
+                        This field is immutable.
+                      type: string
+                  type: object
+                provider:
+                  description: Provider contains all provider-specific and provider-relevant
+                    information.
+                  properties:
+                    controlPlaneConfig:
+                      description: |-
+                        ControlPlaneConfig contains the provider-specific control plane config blob. Please look up the concrete
+                        definition in the documentation of your provider extension.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    infrastructureConfig:
+                      description: |-
+                        InfrastructureConfig contains the provider-specific infrastructure config blob. Please look up the concrete
+                        definition in the documentation of your provider extension.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    type:
+                      description: Type is the type of the provider. This field is
+                        immutable.
+                      type: string
+                    workers:
+                      description: Workers is a list of worker groups.
+                      items:
+                        description: Worker is the base definition of a worker group.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a map of key/value pairs for
+                              annotations for all the `Node` objects in this worker
+                              pool.
+                            type: object
+                          caBundle:
+                            description: CABundle is a certificate bundle which will
+                              be installed onto every machine of this worker pool.
+                            type: string
+                          clusterAutoscaler:
+                            description: ClusterAutoscaler contains the cluster autoscaler
+                              configurations for the worker pool.
+                            properties:
+                              maxNodeProvisionTime:
+                                description: MaxNodeProvisionTime defines how long
+                                  CA waits for node to be provisioned.
+                                type: string
+                              scaleDownGpuUtilizationThreshold:
+                                description: ScaleDownGpuUtilizationThreshold defines
+                                  the threshold in fraction (0.0 - 1.0) of gpu resources
+                                  under which a node is being removed.
+                                type: number
+                              scaleDownUnneededTime:
+                                description: ScaleDownUnneededTime defines how long
+                                  a node should be unneeded before it is eligible
+                                  for scale down.
+                                type: string
+                              scaleDownUnreadyTime:
+                                description: ScaleDownUnreadyTime defines how long
+                                  an unready node should be unneeded before it is
+                                  eligible for scale down.
+                                type: string
+                              scaleDownUtilizationThreshold:
+                                description: ScaleDownUtilizationThreshold defines
+                                  the threshold in fraction (0.0 - 1.0) under which
+                                  a node is being removed.
+                                type: number
+                            type: object
+                          controlPlane:
+                            description: |-
+                              ControlPlane specifies that the shoot cluster control plane components should be running in this worker pool.
+                              This is only relevant for autonomous shoot clusters.
+                            type: object
+                          cri:
+                            description: |-
+                              CRI contains configurations of CRI support of every machine in the worker pool.
+                              Defaults to a CRI with name `containerd`.
+                            properties:
+                              containerRuntimes:
+                                description: ContainerRuntimes is the list of the
+                                  required container runtimes supported for a worker
+                                  pool.
+                                items:
+                                  description: ContainerRuntime contains information
+                                    about worker's available container runtime
+                                  properties:
+                                    providerConfig:
+                                      description: ProviderConfig is the configuration
+                                        passed to container runtime resource.
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type:
+                                      description: Type is the type of the Container
+                                        Runtime.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                type: array
+                              name:
+                                description: The name of the CRI library. Supported
+                                  values are `containerd`.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          dataVolumes:
+                            description: DataVolumes contains a list of additional
+                              worker volumes.
+                            items:
+                              description: DataVolume contains information about a
+                                data volume.
+                              properties:
+                                encrypted:
+                                  description: Encrypted determines if the volume
+                                    should be encrypted.
+                                  type: boolean
+                                name:
+                                  description: Name of the volume to make it referenceable.
+                                  type: string
+                                size:
+                                  description: VolumeSize is the size of the volume.
+                                  type: string
+                                type:
+                                  description: Type is the type of the volume.
+                                  type: string
+                              required:
+                              - name
+                              - size
+                              type: object
+                            type: array
+                          kubeletDataVolumeName:
+                            description: KubeletDataVolumeName contains the name of
+                              a dataVolume that should be used for storing kubelet
+                              state.
+                            type: string
+                          kubernetes:
+                            description: Kubernetes contains configuration for Kubernetes
+                              components related to this worker pool.
+                            properties:
+                              kubelet:
+                                description: |-
+                                  Kubelet contains configuration settings for all kubelets of this worker pool.
+                                  If set, all `spec.kubernetes.kubelet` settings will be overwritten for this worker pool (no merge of settings).
+                                properties:
+                                  containerLogMaxFiles:
+                                    description: Maximum number of container log files
+                                      that can be present for a container.
+                                    format: int32
+                                    type: integer
+                                  containerLogMaxSize:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      A quantity defines the maximum size of the container log file before it is rotated. For example: "5Mi" or "256Ki".
+                                      Default: 100Mi
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  cpuCFSQuota:
+                                    description: CPUCFSQuota allows you to disable/enable
+                                      CPU throttling for Pods.
+                                    type: boolean
+                                  cpuManagerPolicy:
+                                    description: 'CPUManagerPolicy allows to set alternative
+                                      CPU management policies (default: none).'
+                                    type: string
+                                  evictionHard:
+                                    description: |-
+                                      EvictionHard describes a set of eviction thresholds (e.g. memory.available<1Gi) that if met would trigger a Pod eviction.
+                                      Default:
+                                        memory.available:   "100Mi/1Gi/5%"
+                                        nodefs.available:   "5%"
+                                        nodefs.inodesFree:  "5%"
+                                        imagefs.available:  "5%"
+                                        imagefs.inodesFree: "5%"
+                                    properties:
+                                      imageFSAvailable:
+                                        description: ImageFSAvailable is the threshold
+                                          for the free disk space in the imagefs filesystem
+                                          (docker images and container writable layers).
+                                        type: string
+                                      imageFSInodesFree:
+                                        description: ImageFSInodesFree is the threshold
+                                          for the available inodes in the imagefs
+                                          filesystem.
+                                        type: string
+                                      memoryAvailable:
+                                        description: MemoryAvailable is the threshold
+                                          for the free memory on the host server.
+                                        type: string
+                                      nodeFSAvailable:
+                                        description: NodeFSAvailable is the threshold
+                                          for the free disk space in the nodefs filesystem
+                                          (docker volumes, logs, etc).
+                                        type: string
+                                      nodeFSInodesFree:
+                                        description: NodeFSInodesFree is the threshold
+                                          for the available inodes in the nodefs filesystem.
+                                        type: string
+                                    type: object
+                                  evictionMaxPodGracePeriod:
+                                    description: |-
+                                      EvictionMaxPodGracePeriod describes the maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.
+                                      Default: 90
+                                    format: int32
+                                    type: integer
+                                  evictionMinimumReclaim:
+                                    description: |-
+                                      EvictionMinimumReclaim configures the amount of resources below the configured eviction threshold that the kubelet attempts to reclaim whenever the kubelet observes resource pressure.
+                                      Default: 0 for each resource
+                                    properties:
+                                      imageFSAvailable:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: ImageFSAvailable is the threshold
+                                          for the disk space reclaim in the imagefs
+                                          filesystem (docker images and container
+                                          writable layers).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      imageFSInodesFree:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: ImageFSInodesFree is the threshold
+                                          for the inodes reclaim in the imagefs filesystem.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      memoryAvailable:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: MemoryAvailable is the threshold
+                                          for the memory reclaim on the host server.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      nodeFSAvailable:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: NodeFSAvailable is the threshold
+                                          for the disk space reclaim in the nodefs
+                                          filesystem (docker volumes, logs, etc).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      nodeFSInodesFree:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: NodeFSInodesFree is the threshold
+                                          for the inodes reclaim in the nodefs filesystem.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  evictionPressureTransitionPeriod:
+                                    description: |-
+                                      EvictionPressureTransitionPeriod is the duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.
+                                      Default: 4m0s
+                                    type: string
+                                  evictionSoft:
+                                    description: |-
+                                      EvictionSoft describes a set of eviction thresholds (e.g. memory.available<1.5Gi) that if met over a corresponding grace period would trigger a Pod eviction.
+                                      Default:
+                                        memory.available:   "200Mi/1.5Gi/10%"
+                                        nodefs.available:   "10%"
+                                        nodefs.inodesFree:  "10%"
+                                        imagefs.available:  "10%"
+                                        imagefs.inodesFree: "10%"
+                                    properties:
+                                      imageFSAvailable:
+                                        description: ImageFSAvailable is the threshold
+                                          for the free disk space in the imagefs filesystem
+                                          (docker images and container writable layers).
+                                        type: string
+                                      imageFSInodesFree:
+                                        description: ImageFSInodesFree is the threshold
+                                          for the available inodes in the imagefs
+                                          filesystem.
+                                        type: string
+                                      memoryAvailable:
+                                        description: MemoryAvailable is the threshold
+                                          for the free memory on the host server.
+                                        type: string
+                                      nodeFSAvailable:
+                                        description: NodeFSAvailable is the threshold
+                                          for the free disk space in the nodefs filesystem
+                                          (docker volumes, logs, etc).
+                                        type: string
+                                      nodeFSInodesFree:
+                                        description: NodeFSInodesFree is the threshold
+                                          for the available inodes in the nodefs filesystem.
+                                        type: string
+                                    type: object
+                                  evictionSoftGracePeriod:
+                                    description: |-
+                                      EvictionSoftGracePeriod describes a set of eviction grace periods (e.g. memory.available=1m30s) that correspond to how long a soft eviction threshold must hold before triggering a Pod eviction.
+                                      Default:
+                                        memory.available:   1m30s
+                                        nodefs.available:   1m30s
+                                        nodefs.inodesFree:  1m30s
+                                        imagefs.available:  1m30s
+                                        imagefs.inodesFree: 1m30s
+                                    properties:
+                                      imageFSAvailable:
+                                        description: ImageFSAvailable is the grace
+                                          period for the ImageFSAvailable eviction
+                                          threshold.
+                                        type: string
+                                      imageFSInodesFree:
+                                        description: ImageFSInodesFree is the grace
+                                          period for the ImageFSInodesFree eviction
+                                          threshold.
+                                        type: string
+                                      memoryAvailable:
+                                        description: MemoryAvailable is the grace
+                                          period for the MemoryAvailable eviction
+                                          threshold.
+                                        type: string
+                                      nodeFSAvailable:
+                                        description: NodeFSAvailable is the grace
+                                          period for the NodeFSAvailable eviction
+                                          threshold.
+                                        type: string
+                                      nodeFSInodesFree:
+                                        description: NodeFSInodesFree is the grace
+                                          period for the NodeFSInodesFree eviction
+                                          threshold.
+                                        type: string
+                                    type: object
+                                  failSwapOn:
+                                    description: FailSwapOn makes the Kubelet fail
+                                      to start if swap is enabled on the node. (default
+                                      true).
+                                    type: boolean
+                                  featureGates:
+                                    additionalProperties:
+                                      type: boolean
+                                    description: FeatureGates contains information
+                                      about enabled feature gates.
+                                    type: object
+                                  imageGCHighThresholdPercent:
+                                    description: |-
+                                      ImageGCHighThresholdPercent describes the percent of the disk usage which triggers image garbage collection.
+                                      Default: 50
+                                    format: int32
+                                    type: integer
+                                  imageGCLowThresholdPercent:
+                                    description: |-
+                                      ImageGCLowThresholdPercent describes the percent of the disk to which garbage collection attempts to free.
+                                      Default: 40
+                                    format: int32
+                                    type: integer
+                                  kubeReserved:
+                                    description: |-
+                                      KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime).
+                                      When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
+                                      Default: cpu=80m,memory=1Gi,pid=20k
+                                    properties:
+                                      cpu:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: CPU is the reserved cpu.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      ephemeralStorage:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: EphemeralStorage is the reserved
+                                          ephemeral-storage.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      memory:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Memory is the reserved memory.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      pid:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: PID is the reserved process-ids.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  maxPods:
+                                    description: |-
+                                      MaxPods is the maximum number of Pods that are allowed by the Kubelet.
+                                      Default: 110
+                                    format: int32
+                                    type: integer
+                                  memorySwap:
+                                    description: MemorySwap configures swap memory
+                                      available to container workloads.
+                                    properties:
+                                      swapBehavior:
+                                        description: |-
+                                          SwapBehavior configures swap memory available to container workloads. May be one of {"LimitedSwap", "UnlimitedSwap"}
+                                          defaults to: LimitedSwap
+                                        type: string
+                                    type: object
+                                  podPidsLimit:
+                                    description: PodPIDsLimit is the maximum number
+                                      of process IDs per pod allowed by the kubelet.
+                                    format: int64
+                                    type: integer
+                                  protectKernelDefaults:
+                                    description: |-
+                                      ProtectKernelDefaults ensures that the kernel tunables are equal to the kubelet defaults.
+                                      Defaults to true.
+                                    type: boolean
+                                  registryBurst:
+                                    description: |-
+                                      RegistryBurst is the maximum size of bursty pulls, temporarily allows pulls to burst to this number,
+                                      while still not exceeding registryPullQPS. The value must not be a negative number.
+                                      Only used if registryPullQPS is greater than 0.
+                                      Default: 10
+                                    format: int32
+                                    type: integer
+                                  registryPullQPS:
+                                    description: |-
+                                      RegistryPullQPS is the limit of registry pulls per second. The value must not be a negative number.
+                                      Setting it to 0 means no limit.
+                                      Default: 5
+                                    format: int32
+                                    type: integer
+                                  seccompDefault:
+                                    description: SeccompDefault enables the use of
+                                      `RuntimeDefault` as the default seccomp profile
+                                      for all workloads.
+                                    type: boolean
+                                  serializeImagePulls:
+                                    description: |-
+                                      SerializeImagePulls describes whether the images are pulled one at a time.
+                                      Default: true
+                                    type: boolean
+                                  streamingConnectionIdleTimeout:
+                                    description: |-
+                                      StreamingConnectionIdleTimeout is the maximum time a streaming connection can be idle before the connection is automatically closed.
+                                      This field cannot be set lower than "30s" or greater than "4h".
+                                      Default: "5m".
+                                    type: string
+                                  systemReserved:
+                                    description: |-
+                                      SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).
+                                      When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
+
+                                      Deprecated: Separately configuring resource reservations for system processes is deprecated in Gardener and will be forbidden starting from Kubernetes 1.31.
+                                      Please merge existing resource reservations into the kubeReserved field.
+                                    properties:
+                                      cpu:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: CPU is the reserved cpu.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      ephemeralStorage:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: EphemeralStorage is the reserved
+                                          ephemeral-storage.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      memory:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Memory is the reserved memory.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      pid:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: PID is the reserved process-ids.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              version:
+                                description: |-
+                                  Version is the semantic Kubernetes version to use for the Kubelet in this Worker Group.
+                                  If not specified the kubelet version is derived from the global shoot cluster kubernetes version.
+                                  version must be equal or lower than the version of the shoot kubernetes version.
+                                  Only one minor version difference to other worker groups and global kubernetes version is allowed.
+                                type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels is a map of key/value pairs for labels
+                              for all the `Node` objects in this worker pool.
+                            type: object
+                          machine:
+                            description: Machine contains information about the machine
+                              type and image.
+                            properties:
+                              architecture:
+                                description: Architecture is CPU architecture of machines
+                                  in this worker pool.
+                                type: string
+                              image:
+                                description: |-
+                                  Image holds information about the machine image to use for all nodes of this pool. It will default to the
+                                  latest version of the first image stated in the referenced CloudProfile if no value has been provided.
+                                properties:
+                                  name:
+                                    description: Name is the name of the image.
+                                    type: string
+                                  providerConfig:
+                                    description: ProviderConfig is the shoot's individual
+                                      configuration passed to an extension resource.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  version:
+                                    description: |-
+                                      Version is the version of the shoot's image.
+                                      If version is not provided, it will be defaulted to the latest version from the CloudProfile.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type:
+                                description: Type is the machine type of the worker
+                                  group.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          machineControllerManager:
+                            description: MachineControllerManagerSettings contains
+                              configurations for different worker-pools. Eg. MachineDrainTimeout,
+                              MachineHealthTimeout.
+                            properties:
+                              machineCreationTimeout:
+                                description: MachineCreationTimeout is the period
+                                  after which creation of the machine is declared
+                                  failed.
+                                type: string
+                              machineDrainTimeout:
+                                description: MachineDrainTimeout is the period after
+                                  which machine is forcefully deleted.
+                                type: string
+                              machineHealthTimeout:
+                                description: MachineHealthTimeout is the period after
+                                  which machine is declared failed.
+                                type: string
+                              maxEvictRetries:
+                                description: MaxEvictRetries are the number of eviction
+                                  retries on a pod after which drain is declared failed,
+                                  and forceful deletion is triggered.
+                                format: int32
+                                type: integer
+                              nodeConditions:
+                                description: NodeConditions are the set of conditions
+                                  if set to true for the period of MachineHealthTimeout,
+                                  machine will be declared failed.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              MaxSurge is maximum number of machines that are created during an update.
+                              This value is divided by the number of configured zones for a fair distribution.
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              MaxUnavailable is the maximum number of machines that can be unavailable during an update.
+                              This value is divided by the number of configured zones for a fair distribution.
+                            x-kubernetes-int-or-string: true
+                          maximum:
+                            description: |-
+                              Maximum is the maximum number of machines to create.
+                              This value is divided by the number of configured zones for a fair distribution.
+                            format: int32
+                            type: integer
+                          minimum:
+                            description: |-
+                              Minimum is the minimum number of machines to create.
+                              This value is divided by the number of configured zones for a fair distribution.
+                            format: int32
+                            type: integer
+                          name:
+                            description: Name is the name of the worker group.
+                            type: string
+                          priority:
+                            description: Priority (or weight) is the importance by
+                              which this worker group will be scaled by cluster autoscaling.
+                            format: int32
+                            type: integer
+                          providerConfig:
+                            description: ProviderConfig is the provider-specific configuration
+                              for this worker pool.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          sysctls:
+                            additionalProperties:
+                              type: string
+                            description: Sysctls is a map of kernel settings to apply
+                              on all machines in this worker pool.
+                            type: object
+                          systemComponents:
+                            description: SystemComponents contains configuration for
+                              system components related to this worker pool
+                            properties:
+                              allow:
+                                description: Allow determines whether the pool should
+                                  be allowed to host system components or not (defaults
+                                  to true)
+                                type: boolean
+                            required:
+                            - allow
+                            type: object
+                          taints:
+                            description: Taints is a list of taints for all the `Node`
+                              objects in this worker pool.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied
+                                    to a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the
+                                    taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                          updateStrategy:
+                            description: UpdateStrategy specifies the machine update
+                              strategy for the worker pool.
+                            type: string
+                          volume:
+                            description: Volume contains information about the volume
+                              type and size.
+                            properties:
+                              encrypted:
+                                description: Encrypted determines if the volume should
+                                  be encrypted.
+                                type: boolean
+                              name:
+                                description: Name of the volume to make it referenceable.
+                                type: string
+                              size:
+                                description: VolumeSize is the size of the volume.
+                                type: string
+                              type:
+                                description: Type is the type of the volume.
+                                type: string
+                            required:
+                            - size
+                            type: object
+                          zones:
+                            description: |-
+                              Zones is a list of availability zones that are used to evenly distribute this worker pool. Optional
+                              as not every provider may support availability zones.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - machine
+                        - maximum
+                        - minimum
+                        - name
+                        type: object
+                      type: array
+                    workersSettings:
+                      description: WorkersSettings contains settings for all workers.
+                      properties:
+                        sshAccess:
+                          description: SSHAccess contains settings regarding ssh access
+                            to the worker nodes.
+                          properties:
+                            enabled:
+                              description: |-
+                                Enabled indicates whether the SSH access to the worker nodes is ensured to be enabled or disabled in systemd.
+                                Defaults to true.
+                              type: boolean
+                          required:
+                          - enabled
+                          type: object
+                      type: object
+                  required:
+                  - type
+                  type: object
+                purpose:
+                  description: Purpose is the purpose class for this cluster.
+                  type: string
+                region:
+                  description: Region is a name of a region. This field is immutable.
+                  type: string
+                resources:
+                  description: Resources holds a list of named resource references
+                    that can be referred to in extension configs by their names.
+                  items:
+                    description: NamedResourceReference is a named reference to a
+                      resource.
+                    properties:
+                      name:
+                        description: Name of the resource reference.
+                        type: string
+                      resourceRef:
+                        description: ResourceRef is a reference to a resource.
+                        properties:
+                          apiVersion:
+                            description: apiVersion is the API version of the referent
+                            type: string
+                          kind:
+                            description: 'kind is the kind of the referent; More info:
+                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'name is the name of the referent; More info:
+                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - name
+                    - resourceRef
+                    type: object
+                  type: array
+                schedulerName:
+                  description: |-
+                    SchedulerName is the name of the responsible scheduler which schedules the shoot.
+                    If not specified, the default scheduler takes over.
+                    This field is immutable.
+                  type: string
+                secretBindingName:
+                  description: |-
+                    SecretBindingName is the name of a SecretBinding that has a reference to the provider secret.
+                    The credentials inside the provider secret will be used to create the shoot in the respective account.
+                    The field is mutually exclusive with CredentialsBindingName.
+                    This field is immutable.
+                  type: string
+                seedName:
+                  description: SeedName is the name of the seed cluster that runs
+                    the control plane of the Shoot.
+                  type: string
+                seedSelector:
+                  description: SeedSelector is an optional selector which must match
+                    a seed's labels for the shoot to be scheduled on that seed.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                    providerTypes:
+                      description: Providers is optional and can be used by restricting
+                        seeds by their provider type. '*' can be used to enable seeds
+                        regardless of their provider type.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                  x-kubernetes-map-type: atomic
+                systemComponents:
+                  description: SystemComponents contains the settings of system components
+                    in the control or data plane of the Shoot cluster.
+                  properties:
+                    coreDNS:
+                      description: CoreDNS contains the settings of the Core DNS components
+                        running in the data plane of the Shoot cluster.
+                      properties:
+                        autoscaling:
+                          description: Autoscaling contains the settings related to
+                            autoscaling of the Core DNS components running in the
+                            data plane of the Shoot cluster.
+                          properties:
+                            mode:
+                              description: |-
+                                The mode of the autoscaling to be used for the Core DNS components running in the data plane of the Shoot cluster.
+                                Supported values are `horizontal` and `cluster-proportional`.
+                              type: string
+                          required:
+                          - mode
+                          type: object
+                        rewriting:
+                          description: Rewriting contains the setting related to rewriting
+                            of requests, which are obviously incorrect due to the
+                            unnecessary application of the search path.
+                          properties:
+                            commonSuffixes:
+                              description: CommonSuffixes are expected to be the suffix
+                                of a fully qualified domain name. Each suffix should
+                                contain at least one or two dots ('.') to prevent
+                                accidental clashes.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                    nodeLocalDNS:
+                      description: NodeLocalDNS contains the settings of the node
+                        local DNS components running in the data plane of the Shoot
+                        cluster.
+                      properties:
+                        disableForwardToUpstreamDNS:
+                          description: |-
+                            DisableForwardToUpstreamDNS indicates whether requests from node local DNS to upstream DNS should be disabled.
+                            Default, if unspecified, is to forward requests for external domains to upstream DNS
+                          type: boolean
+                        enabled:
+                          description: Enabled indicates whether node local DNS is
+                            enabled or not.
+                          type: boolean
+                        forceTCPToClusterDNS:
+                          description: |-
+                            ForceTCPToClusterDNS indicates whether the connection from the node local DNS to the cluster DNS (Core DNS) will be forced to TCP or not.
+                            Default, if unspecified, is to enforce TCP.
+                          type: boolean
+                        forceTCPToUpstreamDNS:
+                          description: |-
+                            ForceTCPToUpstreamDNS indicates whether the connection from the node local DNS to the upstream DNS (infrastructure DNS) will be forced to TCP or not.
+                            Default, if unspecified, is to enforce TCP.
+                          type: boolean
+                      required:
+                      - enabled
+                      type: object
+                  type: object
+                tolerations:
+                  description: Tolerations contains the tolerations for taints on
+                    seed clusters.
+                  items:
+                    description: Toleration is a toleration for a seed taint.
+                    properties:
+                      key:
+                        description: Key is the toleration key to be applied to a
+                          project or shoot.
+                        type: string
+                      value:
+                        description: Value is the toleration value corresponding to
+                          the toleration key.
+                        type: string
+                    required:
+                    - key
+                    type: object
+                  type: array
+              required:
+              - kubernetes
+              - provider
+              - region
+              type: object
+            version:
+              description: |-
+                Version defines the desired Kubernetes version for the control plane.
+                The value must be a valid semantic version; also if the value provided by the user does not start with the v prefix, it
+                must be added.
+              type: string
+          type: object
+        status:
+          description: GardenerShootControlPlaneStatus defines the observed state
+            of GardenerShootControlPlane.
+          properties:
+            initialized:
+              default: false
+              description: |-
+                Initialized denotes that the foo control plane  API Server is initialized and thus
+                it can accept requests.
+                NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                The value of this field is never updated after provisioning is completed. Please use conditions
+                to check the operational state of the control plane.
+              type: boolean
+            ready:
+              description: |-
+                Ready denotes that the foo control plane is ready to serve requests.
+                NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                The value of this field is never updated after provisioning is completed. Please use conditions
+                to check the operational state of the control plane.
+              type: boolean
+            shootStatus:
+              description: ShootStatus is the status of the Shoot cluster.
+              properties:
+                advertisedAddresses:
+                  description: |-
+                    List of addresses that are relevant to the shoot.
+                    These include the Kube API server address and also the service account issuer.
+                  items:
+                    description: ShootAdvertisedAddress contains information for the
+                      shoot's Kube API server.
+                    properties:
+                      name:
+                        description: Name of the advertised address. e.g. external
+                        type: string
+                      url:
+                        description: The URL of the API Server. e.g. https://api.foo.bar
+                          or https://1.2.3.4
+                        type: string
+                    required:
+                    - name
+                    - url
+                    type: object
+                  type: array
+                clusterIdentity:
+                  description: ClusterIdentity is the identity of the Shoot cluster.
+                    This field is immutable.
+                  type: string
+                conditions:
+                  description: Conditions represents the latest available observations
+                    of a Shoots's current state.
+                  items:
+                    description: Condition holds the information about the state of
+                      a resource.
+                    properties:
+                      codes:
+                        description: Well-defined error codes in case the condition
+                          reports a problem.
+                        items:
+                          description: ErrorCode is a string alias.
+                          type: string
+                        type: array
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one
+                          status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about
+                          the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False,
+                          Unknown.
+                        type: string
+                      type:
+                        description: Type of the condition.
+                        type: string
+                    required:
+                    - lastTransitionTime
+                    - lastUpdateTime
+                    - message
+                    - reason
+                    - status
+                    - type
+                    type: object
+                  type: array
+                constraints:
+                  description: Constraints represents conditions of a Shoot's current
+                    state that constraint some operations on it.
+                  items:
+                    description: Condition holds the information about the state of
+                      a resource.
+                    properties:
+                      codes:
+                        description: Well-defined error codes in case the condition
+                          reports a problem.
+                        items:
+                          description: ErrorCode is a string alias.
+                          type: string
+                        type: array
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one
+                          status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about
+                          the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False,
+                          Unknown.
+                        type: string
+                      type:
+                        description: Type of the condition.
+                        type: string
+                    required:
+                    - lastTransitionTime
+                    - lastUpdateTime
+                    - message
+                    - reason
+                    - status
+                    - type
+                    type: object
+                  type: array
+                credentials:
+                  description: Credentials contains information about the shoot credentials.
+                  properties:
+                    rotation:
+                      description: Rotation contains information about the credential
+                        rotations.
+                      properties:
+                        certificateAuthorities:
+                          description: CertificateAuthorities contains information
+                            about the certificate authority credential rotation.
+                          properties:
+                            lastCompletionTime:
+                              description: |-
+                                LastCompletionTime is the most recent time when the certificate authority credential rotation was successfully
+                                completed.
+                              format: date-time
+                              type: string
+                            lastCompletionTriggeredTime:
+                              description: |-
+                                LastCompletionTriggeredTime is the recent time when the certificate authority credential rotation completion was
+                                triggered.
+                              format: date-time
+                              type: string
+                            lastInitiationFinishedTime:
+                              description: |-
+                                LastInitiationFinishedTime is the recent time when the certificate authority credential rotation initiation was
+                                completed.
+                              format: date-time
+                              type: string
+                            lastInitiationTime:
+                              description: LastInitiationTime is the most recent time
+                                when the certificate authority credential rotation
+                                was initiated.
+                              format: date-time
+                              type: string
+                            pendingWorkersRollouts:
+                              description: |-
+                                PendingWorkersRollouts contains the name of a worker pool and the initiation time of their last rollout due to
+                                credentials rotation.
+                              items:
+                                description: |-
+                                  PendingWorkersRollout contains the name of a worker pool and the initiation time of their last rollout due to
+                                  credentials rotation.
+                                properties:
+                                  lastInitiationTime:
+                                    description: LastInitiationTime is the most recent
+                                      time when the credential rotation was initiated.
+                                    format: date-time
+                                    type: string
+                                  name:
+                                    description: Name is the name of a worker pool.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            phase:
+                              description: Phase describes the phase of the certificate
+                                authority credential rotation.
+                              type: string
+                          required:
+                          - phase
+                          type: object
+                        etcdEncryptionKey:
+                          description: ETCDEncryptionKey contains information about
+                            the ETCD encryption key credential rotation.
+                          properties:
+                            lastCompletionTime:
+                              description: |-
+                                LastCompletionTime is the most recent time when the ETCD encryption key credential rotation was successfully
+                                completed.
+                              format: date-time
+                              type: string
+                            lastCompletionTriggeredTime:
+                              description: |-
+                                LastCompletionTriggeredTime is the recent time when the ETCD encryption key credential rotation completion was
+                                triggered.
+                              format: date-time
+                              type: string
+                            lastInitiationFinishedTime:
+                              description: |-
+                                LastInitiationFinishedTime is the recent time when the ETCD encryption key credential rotation initiation was
+                                completed.
+                              format: date-time
+                              type: string
+                            lastInitiationTime:
+                              description: LastInitiationTime is the most recent time
+                                when the ETCD encryption key credential rotation was
+                                initiated.
+                              format: date-time
+                              type: string
+                            phase:
+                              description: Phase describes the phase of the ETCD encryption
+                                key credential rotation.
+                              type: string
+                          required:
+                          - phase
+                          type: object
+                        kubeconfig:
+                          description: |-
+                            Kubeconfig contains information about the kubeconfig credential rotation.
+
+                            Deprecated: This field is deprecated and will be removed in gardener v1.120
+                          properties:
+                            lastCompletionTime:
+                              description: LastCompletionTime is the most recent time
+                                when the kubeconfig credential rotation was successfully
+                                completed.
+                              format: date-time
+                              type: string
+                            lastInitiationTime:
+                              description: LastInitiationTime is the most recent time
+                                when the kubeconfig credential rotation was initiated.
+                              format: date-time
+                              type: string
+                          type: object
+                        observability:
+                          description: Observability contains information about the
+                            observability credential rotation.
+                          properties:
+                            lastCompletionTime:
+                              description: LastCompletionTime is the most recent time
+                                when the observability credential rotation was successfully
+                                completed.
+                              format: date-time
+                              type: string
+                            lastInitiationTime:
+                              description: LastInitiationTime is the most recent time
+                                when the observability credential rotation was initiated.
+                              format: date-time
+                              type: string
+                          type: object
+                        serviceAccountKey:
+                          description: ServiceAccountKey contains information about
+                            the service account key credential rotation.
+                          properties:
+                            lastCompletionTime:
+                              description: |-
+                                LastCompletionTime is the most recent time when the service account key credential rotation was successfully
+                                completed.
+                              format: date-time
+                              type: string
+                            lastCompletionTriggeredTime:
+                              description: |-
+                                LastCompletionTriggeredTime is the recent time when the service account key credential rotation completion was
+                                triggered.
+                              format: date-time
+                              type: string
+                            lastInitiationFinishedTime:
+                              description: |-
+                                LastInitiationFinishedTime is the recent time when the service account key credential rotation initiation was
+                                completed.
+                              format: date-time
+                              type: string
+                            lastInitiationTime:
+                              description: LastInitiationTime is the most recent time
+                                when the service account key credential rotation was
+                                initiated.
+                              format: date-time
+                              type: string
+                            pendingWorkersRollouts:
+                              description: |-
+                                PendingWorkersRollouts contains the name of a worker pool and the initiation time of their last rollout due to
+                                credentials rotation.
+                              items:
+                                description: |-
+                                  PendingWorkersRollout contains the name of a worker pool and the initiation time of their last rollout due to
+                                  credentials rotation.
+                                properties:
+                                  lastInitiationTime:
+                                    description: LastInitiationTime is the most recent
+                                      time when the credential rotation was initiated.
+                                    format: date-time
+                                    type: string
+                                  name:
+                                    description: Name is the name of a worker pool.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            phase:
+                              description: Phase describes the phase of the service
+                                account key credential rotation.
+                              type: string
+                          required:
+                          - phase
+                          type: object
+                        sshKeypair:
+                          description: SSHKeypair contains information about the ssh-keypair
+                            credential rotation.
+                          properties:
+                            lastCompletionTime:
+                              description: LastCompletionTime is the most recent time
+                                when the ssh-keypair credential rotation was successfully
+                                completed.
+                              format: date-time
+                              type: string
+                            lastInitiationTime:
+                              description: LastInitiationTime is the most recent time
+                                when the ssh-keypair credential rotation was initiated.
+                              format: date-time
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                encryptedResources:
+                  description: |-
+                    EncryptedResources is the list of resources in the Shoot which are currently encrypted.
+                    Secrets are encrypted by default and are not part of the list.
+                    See https://github.com/gardener/gardener/blob/master/docs/usage/security/etcd_encryption_config.md for more details.
+                  items:
+                    type: string
+                  type: array
+                gardener:
+                  description: Gardener holds information about the Gardener which
+                    last acted on the Shoot.
+                  properties:
+                    id:
+                      description: ID is the container id of the Gardener which last
+                        acted on a resource.
+                      type: string
+                    name:
+                      description: Name is the hostname (pod name) of the Gardener
+                        which last acted on a resource.
+                      type: string
+                    version:
+                      description: Version is the version of the Gardener which last
+                        acted on a resource.
+                      type: string
+                  required:
+                  - id
+                  - name
+                  - version
+                  type: object
+                hibernated:
+                  description: IsHibernated indicates whether the Shoot is currently
+                    hibernated.
+                  type: boolean
+                lastErrors:
+                  description: LastErrors holds information about the last occurred
+                    error(s) during an operation.
+                  items:
+                    description: LastError indicates the last occurred error for an
+                      operation on a resource.
+                    properties:
+                      codes:
+                        description: Well-defined error codes of the last error(s).
+                        items:
+                          description: ErrorCode is a string alias.
+                          type: string
+                        type: array
+                      description:
+                        description: A human readable message indicating details about
+                          the last error.
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the error was reported
+                        format: date-time
+                        type: string
+                      taskID:
+                        description: ID of the task which caused this last error
+                        type: string
+                    required:
+                    - description
+                    type: object
+                  type: array
+                lastHibernationTriggerTime:
+                  description: |-
+                    LastHibernationTriggerTime indicates the last time when the hibernation controller
+                    managed to change the hibernation settings of the cluster
+                  format: date-time
+                  type: string
+                lastMaintenance:
+                  description: LastMaintenance holds information about the last maintenance
+                    operations on the Shoot.
+                  properties:
+                    description:
+                      description: A human-readable message containing details about
+                        the operations performed in the last maintenance.
+                      type: string
+                    failureReason:
+                      description: FailureReason holds the information about the last
+                        maintenance operation failure reason.
+                      type: string
+                    state:
+                      description: Status of the last maintenance operation, one of
+                        Processing, Succeeded, Error.
+                      type: string
+                    triggeredTime:
+                      description: TriggeredTime is the time when maintenance was
+                        triggered.
+                      format: date-time
+                      type: string
+                  required:
+                  - description
+                  - state
+                  - triggeredTime
+                  type: object
+                lastOperation:
+                  description: LastOperation holds information about the last operation
+                    on the Shoot.
+                  properties:
+                    description:
+                      description: A human readable message indicating details about
+                        the last operation.
+                      type: string
+                    lastUpdateTime:
+                      description: Last time the operation state transitioned from
+                        one to another.
+                      format: date-time
+                      type: string
+                    progress:
+                      description: The progress in percentage (0-100) of the last
+                        operation.
+                      format: int32
+                      type: integer
+                    state:
+                      description: Status of the last operation, one of Aborted, Processing,
+                        Succeeded, Error, Failed.
+                      type: string
+                    type:
+                      description: Type of the last operation, one of Create, Reconcile,
+                        Delete, Migrate, Restore.
+                      type: string
+                  required:
+                  - description
+                  - lastUpdateTime
+                  - progress
+                  - state
+                  - type
+                  type: object
+                migrationStartTime:
+                  description: MigrationStartTime is the time when a migration to
+                    a different seed was initiated.
+                  format: date-time
+                  type: string
+                networking:
+                  description: Networking contains information about cluster networking
+                    such as CIDRs.
+                  properties:
+                    egressCIDRs:
+                      description: |-
+                        EgressCIDRs is a list of CIDRs used by the shoot as the source IP for egress traffic as reported by the used
+                        Infrastructure extension controller. For certain environments the egress IPs may not be stable in which case the
+                        extension controller may opt to not populate this field.
+                      items:
+                        type: string
+                      type: array
+                    nodes:
+                      description: Nodes are the CIDRs of the node network.
+                      items:
+                        type: string
+                      type: array
+                    pods:
+                      description: Pods are the CIDRs of the pod network.
+                      items:
+                        type: string
+                      type: array
+                    services:
+                      description: Services are the CIDRs of the service network.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the most recent generation observed for this Shoot. It corresponds to the
+                    Shoot's generation, which is updated on mutation by the API Server.
+                  format: int64
+                  type: integer
+                retryCycleStartTime:
+                  description: |-
+                    RetryCycleStartTime is the start time of the last retry cycle (used to determine how often an operation
+                    must be retried until we give up).
+                  format: date-time
+                  type: string
+                seedName:
+                  description: |-
+                    SeedName is the name of the seed cluster that runs the control plane of the Shoot. This value is only written
+                    after a successful create/reconcile operation. It will be used when control planes are moved between Seeds.
+                  type: string
+                technicalID:
+                  description: |-
+                    TechnicalID is a unique technical ID for this Shoot. It is used for the infrastructure resources, and
+                    basically everything that is related to this particular Shoot. For regular shoot clusters, this is also the name
+                    of the namespace in the seed cluster running the shoot's control plane. This field is immutable.
+                  type: string
+                uid:
+                  description: |-
+                    UID is a unique identifier for the Shoot cluster to avoid portability between Kubernetes clusters.
+                    It is used to compute unique hashes. This field is immutable.
+                  type: string
+              required:
+              - gardener
+              - hibernated
+              - technicalID
+              - uid
+              type: object
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/schemas/gardener/apiresourceschema-gardenershootcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/schemas/gardener/apiresourceschema-gardenershootcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -1,7 +1,6 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  creationTimestamp: null
   name: v250401-cfe2a97.gardenershootcontrolplanes.controlplane.cluster.x-k8s.io
 spec:
   group: controlplane.cluster.x-k8s.io


### PR DESCRIPTION
This PR includes several improvements in regards to KCP-awareness, including, but not limited to:
- Changing the mapping behavior from `Shoot`s to `GSCP`s
- Adding a mock controller for the CAPI in KCP "showcase"
- Fixing a bug, where we used the wrong client to create the `AdminKubeconfigRequest` 😛