### PR TITLE
Adapt `create workspace` command / fix defaulting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ kubectl apply -f schemas/binding.yaml
 **Run controller:**
 ```shell
 go run cmd/main.go --kubeconfig <path/to/kcp-kubeconfig> --gardener-kubeconfig  <path/to/gardener/kubeconfig.yaml>
-
 ```
 
 **Create and enter consuming workspace:**

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ kubectl apply -f schemas/gardener
 kubectl apply -f schemas/binding.yaml
 ```
 
+**Run controller:**
+```shell
+go run cmd/main.go --kubeconfig <path/to/kcp-kubeconfig> --gardener-kubeconfig  <path/to/gardener/kubeconfig.yaml>
+
+```
+
 **Create and enter consuming workspace:**
 ```shell
 kubectl create workspace test --enter

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please refer to the individual scenario of your choice for the specific prerequi
 **Create controller workspace:**
 > **NOTE**: For our quick-start, we use `:root:gardener` as our controller-workspace.
 ```shell
-kubectl create-workspace gardener --enter
+kubectl create workspace gardener --enter
 ```
 
 **Create `APIResourceSchema`s, `APIExport` and `APIBinding` in Controller-workspace:**
@@ -48,7 +48,7 @@ kubectl apply -f schemas/binding.yaml
 
 **Create and enter consuming workspace:**
 ```shell
-kubectl create-workspace test --enter
+kubectl create workspace test --enter
 ```
 
 **Create `APIBinding` for consuming workspace:**

--- a/config/samples/controlplane_v1alpha1_gardenershootcontrolplane.yaml
+++ b/config/samples/controlplane_v1alpha1_gardenershootcontrolplane.yaml
@@ -7,6 +7,7 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
     kind: GardenerShootControlPlane
     name: hello-gardener
+    namespace: default
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
 kind: GardenerShootControlPlane

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -58,7 +58,7 @@ func (r *ClusterController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	cluster.Status = v1beta1.ClusterStatus{
 		Phase:               string(v1beta1.ClusterPhaseProvisioned),
 		InfrastructureReady: true,
-		ControlPlaneReady:   true,
+		ControlPlaneReady:   gscp.Status.Initialized,
 		ObservedGeneration:  cluster.Generation,
 	}
 	if !gscp.Status.Initialized {

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -55,17 +55,18 @@ func (r *ClusterController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	if gscp.Status.Initialized {
-		cluster.Status = v1beta1.ClusterStatus{
-			Phase:               string(v1beta1.ClusterPhaseProvisioned),
-			InfrastructureReady: true,
-			ControlPlaneReady:   true,
-			ObservedGeneration:  cluster.Generation,
-		}
-		if err := r.Client.Status().Update(ctx, &cluster); err != nil {
-			log.Error(err, "unable to update cluster status")
-			return ctrl.Result{}, err
-		}
+	cluster.Status = v1beta1.ClusterStatus{
+		Phase:               string(v1beta1.ClusterPhaseProvisioned),
+		InfrastructureReady: true,
+		ControlPlaneReady:   true,
+		ObservedGeneration:  cluster.Generation,
+	}
+	if !gscp.Status.Initialized {
+		cluster.Status.Phase = string(v1beta1.ClusterPhaseProvisioning)
+	}
+	if err := r.Client.Status().Update(ctx, &cluster); err != nil {
+		log.Error(err, "unable to update cluster status")
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil

--- a/schemas/gardener/apiexport-controlplane.cluster.x-k8s.io.yaml
+++ b/schemas/gardener/apiexport-controlplane.cluster.x-k8s.io.yaml
@@ -10,12 +10,3 @@ spec:
     - group: ""
       resource: "secrets"
       all: true
----
-apiVersion: apis.kcp.io/v1alpha1
-kind: APIExportEndpointSlice
-metadata:
-  name: controlplane.cluster.x-k8s.io
-spec:
-  export:
-    path: "root:gardener"
-    name: controlplane.cluster.x-k8s.io


### PR DESCRIPTION
The `create-workspace` plugin now works with a space and not a hyphen.
Fix defaulting for GSCP reference in `Cluster` object