### PR TITLE
Enable image replacement through `kustomize`

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,7 +64,7 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
           - --gardener-kubeconfig=/etc/gardener-kubeconfig/kubeconfig
-        image: localhost:5001/cluster-api-provider-gardener/controller:latest
+        image: controller
         name: manager
         ports: []
         securityContext:


### PR DESCRIPTION
This is needed, so that the image replacement done through the [Make target](https://github.com/LucaBernstein/cluster-api-provider-gardener/blob/568a2f9c58067a40a4210f2f5057538ffe50ec7d/config/manager/kustomization.yaml#L6-L9)
Can actually replace this tag.
Without this, specifying the `IMG` env variable has no effect.